### PR TITLE
Adds a warm-up run of the benchmark to reduce variance.

### DIFF
--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -47,6 +47,9 @@ public struct BenchmarkRunner {
         var measurements: [Double] = []
         measurements.reserveCapacity(iterations)
 
+        // Perform a warm-up iteration.
+        benchmark.run()
+
         for _ in 1...iterations {
             clock.recordStart()
             benchmark.run()


### PR DESCRIPTION
Previously, the first run of the benchmark could have large swings
in performance due to warm-up effects. In order to get more
accurate measurements, we should include a warm-up run which
should appropriately warm up caches / etc.