### PR TITLE
Allow benchmarks to run a configurable number of times.

### DIFF
--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -14,15 +14,18 @@
 
 public protocol AnyBenchmark {
     var name: String { get }
+    var defaultIterations: Int { get }
     func run()
 }
 
 internal class ClosureBenchmark: AnyBenchmark {
     let name: String
+    let defaultIterations: Int
     let closure: () -> Void
 
-    init(_ name: String, _ closure: @escaping () -> Void) {
+    init(_ name: String, defaultIterations: Int, _ closure: @escaping () -> Void) {
         self.name = name
+        self.defaultIterations = defaultIterations
         self.closure = closure
     }
 

--- a/Sources/Benchmark/BenchmarkMain.swift
+++ b/Sources/Benchmark/BenchmarkMain.swift
@@ -15,8 +15,7 @@
 public func main(_ suites: [BenchmarkSuite]) {
     var runner = BenchmarkRunner(
         suites: suites,
-        reporter: PlainTextReporter(),
-        iterations: 10000)
+        reporter: PlainTextReporter())
     runner.run()
 }
 

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -15,16 +15,13 @@
 public struct BenchmarkRunner {
     let suites: [BenchmarkSuite]
     let reporter: BenchmarkReporter
-    let iterations: Int
     var results: [BenchmarkResult] = []
 
     init(
-        suites: [BenchmarkSuite], reporter: BenchmarkReporter,
-        iterations: Int
+        suites: [BenchmarkSuite], reporter: BenchmarkReporter
     ) {
         self.suites = suites
         self.reporter = reporter
-        self.iterations = iterations
     }
 
     mutating func run() {
@@ -45,9 +42,9 @@ public struct BenchmarkRunner {
 
         var clock = BenchmarkClock()
         var measurements: [Double] = []
-        measurements.reserveCapacity(iterations)
+        measurements.reserveCapacity(benchmark.defaultIterations)
 
-        for _ in 1...iterations {
+        for _ in 1...benchmark.defaultIterations {
             clock.recordStart()
             benchmark.run()
             clock.recordEnd()

--- a/Sources/Benchmark/BenchmarkSuite.swift
+++ b/Sources/Benchmark/BenchmarkSuite.swift
@@ -29,8 +29,8 @@ public class BenchmarkSuite {
         benchmarks.append(benchmark)
     }
 
-    public func benchmark(_ name: String, _ f: @escaping () -> Void) {
-        let benchmark = ClosureBenchmark(name, f)
+    public func benchmark(_ name: String, defaultIterations: Int = 10000, _ f: @escaping () -> Void) {
+        let benchmark = ClosureBenchmark(name, defaultIterations: defaultIterations, f)
         register(benchmark: benchmark)
     }
 }

--- a/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
@@ -55,8 +55,7 @@ extension BenchmarkRunnerTests {
 
         var runner = BenchmarkRunner(
             suites: [suite1, suite2],
-            reporter: BlackHoleReporter(),
-            iterations: 1)
+            reporter: BlackHoleReporter())
 
         runner.run(options: options)
         return benchmarksRun


### PR DESCRIPTION
While we should make it so that benchmarks run a variable number of times
based on how short they are (in order to amortize overhead away), we should
in the meantime allow the iteration count to be configurable by the end
user.