### PR TITLE
Fix #12: integrate command-line arguments with multi-level settings

### DIFF
--- a/Sources/Benchmark/BenchmarkCommand.swift
+++ b/Sources/Benchmark/BenchmarkCommand.swift
@@ -1,0 +1,76 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ArgumentParser
+import Foundation
+
+/// Allows dynamic configuration of the benchmark execution.
+internal struct BenchmarkCommand: ParsableCommand {
+    @Option(
+        help: "Run only benchmarks whose names match the regular expression.",
+        transform: BenchmarkFilter.init)
+    var filter: BenchmarkFilter?
+
+    @Flag(help: "Overrides check to verify optimized build.")
+    var allowDebugBuild: Bool
+
+    mutating func validate() throws {
+        var isDebug = false
+        assert(
+            {
+                isDebug = true
+                return true
+            }())
+        if isDebug && !allowDebugBuild {
+            throw ValidationError(debugBuildErrorMessage)
+        }
+    }
+
+    var debugBuildErrorMessage: String {
+        """
+        Please build with optimizations enabled (`-c release` if using SwiftPM,
+        `-c opt` if using bazel, or `-O` if using swiftc directly). If you would really
+        like to run the benchmark without optimizations, pass the `--allow-debug-build`
+        flag.
+        """
+    }
+}
+
+extension BenchmarkCommand {
+    func matches(suiteName: String, benchmarkName: String) -> Bool {
+        guard let filter = filter else { return true }
+        return filter.matches(suiteName: suiteName, benchmarkName: benchmarkName)
+    }
+
+    init(filter: String) throws {
+        self.filter = try BenchmarkFilter(filter)
+        self.allowDebugBuild = false
+    }
+}
+
+internal struct BenchmarkFilter {
+    let underlying: NSRegularExpression
+
+    init(_ regularExpression: String) throws {
+        underlying = try NSRegularExpression(
+            pattern: regularExpression,
+            options: [.caseInsensitive, .anchorsMatchLines])
+    }
+
+    func matches(suiteName: String, benchmarkName: String) -> Bool {
+        let str = "\(suiteName)/\(benchmarkName)"
+        let range = NSRange(location: 0, length: str.utf16.count)
+        return underlying.firstMatch(in: str, range: range) != nil
+    }
+}

--- a/Sources/Benchmark/BenchmarkCommand.swift
+++ b/Sources/Benchmark/BenchmarkCommand.swift
@@ -17,11 +17,14 @@ import Foundation
 
 /// Allows dynamic configuration of the benchmark execution.
 internal struct BenchmarkCommand: ParsableCommand {
+    @Flag(help: "Overrides check to verify optimized build.")
+    var allowDebugBuild: Bool
+
     @Option(help: "Run only benchmarks whose names match the regular expression.")
     var filter: String?
 
-    @Flag(help: "Overrides check to verify optimized build.")
-    var allowDebugBuild: Bool
+    @Option(help: "Number of iterations to run.")
+    var iterations: Int?
 
     mutating func validate() throws {
         var isDebug = false
@@ -32,6 +35,9 @@ internal struct BenchmarkCommand: ParsableCommand {
             }())
         if isDebug && !allowDebugBuild {
             throw ValidationError(debugBuildErrorMessage)
+        }
+        if iterations != nil && iterations! <= 0 {
+            throw ValidationError(iterationsErrorMessage)
         }
     }
 
@@ -44,12 +50,19 @@ internal struct BenchmarkCommand: ParsableCommand {
         """
     }
 
+    var iterationsErrorMessage: String {
+        "Please make sure that number of iterations provided is a positive integer number."
+    }
+
     var settings: [BenchmarkSetting] {
         var result: [BenchmarkSetting] = []
+        result.append(.allowDebugBuild(allowDebugBuild))
         if filter != nil {
             result.append(.filter(filter!))
         }
-        result.append(.allowDebugBuild(allowDebugBuild))
+        if iterations != nil {
+            result.append(.iterations(iterations!))
+        }
         return result
     }
 }

--- a/Sources/Benchmark/BenchmarkCommand.swift
+++ b/Sources/Benchmark/BenchmarkCommand.swift
@@ -26,6 +26,24 @@ internal struct BenchmarkCommand: ParsableCommand {
     @Option(help: "Number of iterations to run.")
     var iterations: Int?
 
+    @Option(help: "Number of warm-up iterations to run.")
+    var warmupIterations: Int?
+
+    var settings: [BenchmarkSetting] {
+        var result: [BenchmarkSetting] = []
+        result.append(.allowDebugBuild(allowDebugBuild))
+        if filter != nil {
+            result.append(.filter(filter!))
+        }
+        if iterations != nil {
+            result.append(.iterations(iterations!))
+        }
+        if warmupIterations != nil {
+            result.append(.warmupIterations(warmupIterations!))
+        }
+        return result
+    }
+
     mutating func validate() throws {
         var isDebug = false
         assert(
@@ -51,18 +69,6 @@ internal struct BenchmarkCommand: ParsableCommand {
     }
 
     var iterationsErrorMessage: String {
-        "Please make sure that number of iterations provided is a positive integer number."
-    }
-
-    var settings: [BenchmarkSetting] {
-        var result: [BenchmarkSetting] = []
-        result.append(.allowDebugBuild(allowDebugBuild))
-        if filter != nil {
-            result.append(.filter(filter!))
-        }
-        if iterations != nil {
-            result.append(.iterations(iterations!))
-        }
-        return result
+        "Please make sure that number of iterations is a positive integer number."
     }
 }

--- a/Sources/Benchmark/BenchmarkCommand.swift
+++ b/Sources/Benchmark/BenchmarkCommand.swift
@@ -17,10 +17,8 @@ import Foundation
 
 /// Allows dynamic configuration of the benchmark execution.
 internal struct BenchmarkCommand: ParsableCommand {
-    @Option(
-        help: "Run only benchmarks whose names match the regular expression.",
-        transform: BenchmarkFilter.init)
-    var filter: BenchmarkFilter?
+    @Option(help: "Run only benchmarks whose names match the regular expression.")
+    var filter: String?
 
     @Flag(help: "Overrides check to verify optimized build.")
     var allowDebugBuild: Bool
@@ -45,32 +43,13 @@ internal struct BenchmarkCommand: ParsableCommand {
         flag.
         """
     }
-}
 
-extension BenchmarkCommand {
-    func matches(suiteName: String, benchmarkName: String) -> Bool {
-        guard let filter = filter else { return true }
-        return filter.matches(suiteName: suiteName, benchmarkName: benchmarkName)
-    }
-
-    init(filter: String) throws {
-        self.filter = try BenchmarkFilter(filter)
-        self.allowDebugBuild = false
-    }
-}
-
-internal struct BenchmarkFilter {
-    let underlying: NSRegularExpression
-
-    init(_ regularExpression: String) throws {
-        underlying = try NSRegularExpression(
-            pattern: regularExpression,
-            options: [.caseInsensitive, .anchorsMatchLines])
-    }
-
-    func matches(suiteName: String, benchmarkName: String) -> Bool {
-        let str = "\(suiteName)/\(benchmarkName)"
-        let range = NSRange(location: 0, length: str.utf16.count)
-        return underlying.firstMatch(in: str, range: range) != nil
+    var settings: [BenchmarkSetting] {
+        var result: [BenchmarkSetting] = []
+        if filter != nil {
+            result.append(.filter(filter!))
+        }
+        result.append(.allowDebugBuild(allowDebugBuild))
+        return result
     }
 }

--- a/Sources/Benchmark/BenchmarkCommand.swift
+++ b/Sources/Benchmark/BenchmarkCommand.swift
@@ -31,7 +31,6 @@ internal struct BenchmarkCommand: ParsableCommand {
 
     var settings: [BenchmarkSetting] {
         var result: [BenchmarkSetting] = []
-        result.append(.allowDebugBuild(allowDebugBuild))
         if filter != nil {
             result.append(.filter(filter!))
         }

--- a/Sources/Benchmark/BenchmarkFilter.swift
+++ b/Sources/Benchmark/BenchmarkFilter.swift
@@ -23,12 +23,12 @@ internal struct BenchmarkFilter {
                 pattern: regularExpression!,
                 options: [.caseInsensitive, .anchorsMatchLines])
         } else {
-          self.underlying = nil
+            self.underlying = nil
         }
     }
 
     func matches(suiteName: String, benchmarkName: String) -> Bool {
-        if underlying == nil { 
+        if underlying == nil {
             return true
         } else {
             let str = "\(suiteName)/\(benchmarkName)"

--- a/Sources/Benchmark/BenchmarkFilter.swift
+++ b/Sources/Benchmark/BenchmarkFilter.swift
@@ -1,0 +1,39 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+internal struct BenchmarkFilter {
+    let underlying: NSRegularExpression?
+
+    init(_ regularExpression: String?) throws {
+        if regularExpression != nil {
+            self.underlying = try NSRegularExpression(
+                pattern: regularExpression!,
+                options: [.caseInsensitive, .anchorsMatchLines])
+        } else {
+          self.underlying = nil
+        }
+    }
+
+    func matches(suiteName: String, benchmarkName: String) -> Bool {
+        if underlying == nil { 
+            return true
+        } else {
+            let str = "\(suiteName)/\(benchmarkName)"
+            let range = NSRange(location: 0, length: str.utf16.count)
+            return underlying!.firstMatch(in: str, range: range) != nil
+        }
+    }
+}

--- a/Sources/Benchmark/BenchmarkMain.swift
+++ b/Sources/Benchmark/BenchmarkMain.swift
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 public func main(_ suites: [BenchmarkSuite]) {
-    let options = BenchmarkRunnerOptions.parseOrExit()
+    let command = BenchmarkCommand.parseOrExit()
 
     var runner = BenchmarkRunner(
         suites: suites,
         reporter: PlainTextReporter())
-    runner.run(options: options)
+    runner.run(command: command)
 }
 
 public func main() {

--- a/Sources/Benchmark/BenchmarkMain.swift
+++ b/Sources/Benchmark/BenchmarkMain.swift
@@ -14,11 +14,14 @@
 
 public func main(_ suites: [BenchmarkSuite]) {
     let command = BenchmarkCommand.parseOrExit()
+    let settings = command.settings
+    let reporter = PlainTextReporter()
 
     var runner = BenchmarkRunner(
         suites: suites,
-        reporter: PlainTextReporter())
-    runner.run(command: command)
+        settings: settings,
+        reporter: reporter)
+    try! runner.run()
 }
 
 public func main() {

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import ArgumentParser
-import Foundation
-
 public struct BenchmarkRunner {
     let suites: [BenchmarkSuite]
     let reporter: BenchmarkReporter
@@ -25,16 +22,16 @@ public struct BenchmarkRunner {
         self.reporter = reporter
     }
 
-    mutating func run(options: BenchmarkRunnerOptions) {
+    mutating func run(command: BenchmarkCommand) {
         for suite in suites {
-            run(suite: suite, options: options)
+            run(suite: suite, command: command)
         }
         reporter.report(results: results)
     }
 
-    mutating func run(suite: BenchmarkSuite, options: BenchmarkRunnerOptions) {
+    mutating func run(suite: BenchmarkSuite, command: BenchmarkCommand) {
         for benchmark in suite.benchmarks {
-            if !options.matches(suiteName: suite.name, benchmarkName: benchmark.name) { continue }
+            if !command.matches(suiteName: suite.name, benchmarkName: benchmark.name) { continue }
             run(benchmark: benchmark, suite: suite)
         }
     }
@@ -62,65 +59,5 @@ public struct BenchmarkRunner {
             suiteName: suite.name,
             measurements: measurements)
         results.append(result)
-    }
-}
-
-/// Allows dynamic configuration of the benchmark execution.
-internal struct BenchmarkRunnerOptions: ParsableCommand {
-    @Option(
-        help: "Run only benchmarks whose names match the regular expression.",
-        transform: BenchmarkFilter.init)
-    var filter: BenchmarkFilter?
-
-    @Flag(help: "Overrides check to verify optimized build.")
-    var allowDebugBuild: Bool
-
-    mutating func validate() throws {
-        var isDebug = false
-        assert(
-            {
-                isDebug = true
-                return true
-            }())
-        if isDebug && !allowDebugBuild {
-            throw ValidationError(debugBuildErrorMessage)
-        }
-    }
-
-    var debugBuildErrorMessage: String {
-        """
-        Please build with optimizations enabled (`-c release` if using SwiftPM,
-        `-c opt` if using bazel, or `-O` if using swiftc directly). If you would really
-        like to run the benchmark without optimizations, pass the `--allow-debug-build`
-        flag.
-        """
-    }
-}
-
-extension BenchmarkRunnerOptions {
-    func matches(suiteName: String, benchmarkName: String) -> Bool {
-        guard let filter = filter else { return true }
-        return filter.matches(suiteName: suiteName, benchmarkName: benchmarkName)
-    }
-
-    init(filter: String) throws {
-        self.filter = try BenchmarkFilter(filter)
-        self.allowDebugBuild = false
-    }
-}
-
-internal struct BenchmarkFilter {
-    let underlying: NSRegularExpression
-
-    init(_ regularExpression: String) throws {
-        underlying = try NSRegularExpression(
-            pattern: regularExpression,
-            options: [.caseInsensitive, .anchorsMatchLines])
-    }
-
-    func matches(suiteName: String, benchmarkName: String) -> Bool {
-        let str = "\(suiteName)/\(benchmarkName)"
-        let range = NSRange(location: 0, length: str.utf16.count)
-        return underlying.firstMatch(in: str, range: range) != nil
     }
 }

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -55,8 +55,11 @@ public struct BenchmarkRunner {
         var measurements: [Double] = []
         measurements.reserveCapacity(settings.iterations)
 
-        // Perform a warm-up iteration.
-        benchmark.run()
+        if settings.warmupIterations > 0 {
+            for _ in 1...settings.warmupIterations {
+                benchmark.run()
+            }
+        }
 
         for _ in 1...settings.iterations {
             clock.recordStart()

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -39,10 +39,10 @@ public struct BenchmarkRunner {
 
     mutating func run(benchmark: AnyBenchmark, suite: BenchmarkSuite) throws {
         let settings = try BenchmarkSettings([
-            defaultSettings, 
-            self.settings, 
-            suite.settings, 
-            benchmark.settings
+            defaultSettings,
+            self.settings,
+            suite.settings,
+            benchmark.settings,
         ])
 
         if !settings.filter.matches(suiteName: suite.name, benchmarkName: benchmark.name) {

--- a/Sources/Benchmark/BenchmarkSetting.swift
+++ b/Sources/Benchmark/BenchmarkSetting.swift
@@ -14,12 +14,14 @@
 
 public enum BenchmarkSetting {
     case iterations(Int)
+    case warmupIterations(Int)
     case filter(String)
     case allowDebugBuild(Bool)
 }
 
 struct BenchmarkSettings {
     let iterations: Int
+    let warmupIterations: Int
     let filter: BenchmarkFilter
     let allowDebugBuild: Bool
 
@@ -29,6 +31,7 @@ struct BenchmarkSettings {
 
     init(_ settings: [BenchmarkSetting]) throws {
         var iterations: Int = -1
+        var warmupIterations: Int = -1
         var filter: String? = nil
         var allowDebugBuild: Bool = false
 
@@ -36,6 +39,8 @@ struct BenchmarkSettings {
             switch setting {
             case .iterations(let value):
                 iterations = value
+            case .warmupIterations(let value):
+                warmupIterations = value
             case .filter(let value):
                 filter = value
             case .allowDebugBuild(let value):
@@ -43,11 +48,17 @@ struct BenchmarkSettings {
             }
         }
 
-        try self.init(iterations: iterations, filter: filter, allowDebugBuild: allowDebugBuild)
+        try self.init(
+            iterations: iterations, 
+            warmupIterations: warmupIterations,
+            filter: filter, 
+            allowDebugBuild: 
+            allowDebugBuild)
     }
 
-    init(iterations: Int, filter: String?, allowDebugBuild: Bool) throws {
+    init(iterations: Int, warmupIterations: Int, filter: String?, allowDebugBuild: Bool) throws {
         self.iterations = iterations
+        self.warmupIterations = warmupIterations
         self.filter = try BenchmarkFilter(filter)
         self.allowDebugBuild = allowDebugBuild
     }
@@ -55,5 +66,6 @@ struct BenchmarkSettings {
 
 let defaultSettings: [BenchmarkSetting] = [
     .iterations(100000),
+    .warmupIterations(1),
     .allowDebugBuild(false),
 ]

--- a/Sources/Benchmark/BenchmarkSetting.swift
+++ b/Sources/Benchmark/BenchmarkSetting.swift
@@ -14,29 +14,46 @@
 
 public enum BenchmarkSetting {
     case iterations(Int)
+    case filter(String)
+    case allowDebugBuild(Bool)
 }
 
 struct BenchmarkSettings {
     let iterations: Int
+    let filter: BenchmarkFilter
+    let allowDebugBuild: Bool
 
-    init(_ settings: [[BenchmarkSetting]]) {
-        self.init(Array(settings.joined()))
+    init(_ settings: [[BenchmarkSetting]]) throws {
+        try self.init(Array(settings.joined()))
     }
 
-    init(_ settings: [BenchmarkSetting]) {
+    init(_ settings: [BenchmarkSetting]) throws {
         var iterations: Int = -1
+        var filter: String? = nil
+        var allowDebugBuild: Bool = false
 
         for setting in settings {
             switch setting {
             case .iterations(let value):
                 iterations = value
+            case .filter(let value):
+                filter = value
+            case .allowDebugBuild(let value):
+                allowDebugBuild = value
             }
         }
 
+        try self.init(iterations: iterations, filter: filter, allowDebugBuild: allowDebugBuild)
+    }
+
+    init(iterations: Int, filter: String?, allowDebugBuild: Bool) throws {
         self.iterations = iterations
+        self.filter = try BenchmarkFilter(filter)
+        self.allowDebugBuild = allowDebugBuild
     }
 }
 
 let defaultSettings: [BenchmarkSetting] = [
-    .iterations(100000)
+    .iterations(100000),
+    .allowDebugBuild(false),
 ]

--- a/Sources/Benchmark/BenchmarkSetting.swift
+++ b/Sources/Benchmark/BenchmarkSetting.swift
@@ -16,14 +16,12 @@ public enum BenchmarkSetting {
     case iterations(Int)
     case warmupIterations(Int)
     case filter(String)
-    case allowDebugBuild(Bool)
 }
 
 struct BenchmarkSettings {
     let iterations: Int
     let warmupIterations: Int
     let filter: BenchmarkFilter
-    let allowDebugBuild: Bool
 
     init(_ settings: [[BenchmarkSetting]]) throws {
         try self.init(Array(settings.joined()))
@@ -33,7 +31,6 @@ struct BenchmarkSettings {
         var iterations: Int = -1
         var warmupIterations: Int = -1
         var filter: String? = nil
-        var allowDebugBuild: Bool = false
 
         for setting in settings {
             switch setting {
@@ -43,29 +40,23 @@ struct BenchmarkSettings {
                 warmupIterations = value
             case .filter(let value):
                 filter = value
-            case .allowDebugBuild(let value):
-                allowDebugBuild = value
             }
         }
 
         try self.init(
             iterations: iterations,
             warmupIterations: warmupIterations,
-            filter: filter,
-            allowDebugBuild:
-                allowDebugBuild)
+            filter: filter)
     }
 
-    init(iterations: Int, warmupIterations: Int, filter: String?, allowDebugBuild: Bool) throws {
+    init(iterations: Int, warmupIterations: Int, filter: String?) throws {
         self.iterations = iterations
         self.warmupIterations = warmupIterations
         self.filter = try BenchmarkFilter(filter)
-        self.allowDebugBuild = allowDebugBuild
     }
 }
 
 let defaultSettings: [BenchmarkSetting] = [
     .iterations(100000),
     .warmupIterations(1),
-    .allowDebugBuild(false),
 ]

--- a/Sources/Benchmark/BenchmarkSetting.swift
+++ b/Sources/Benchmark/BenchmarkSetting.swift
@@ -49,11 +49,11 @@ struct BenchmarkSettings {
         }
 
         try self.init(
-            iterations: iterations, 
+            iterations: iterations,
             warmupIterations: warmupIterations,
-            filter: filter, 
-            allowDebugBuild: 
-            allowDebugBuild)
+            filter: filter,
+            allowDebugBuild:
+                allowDebugBuild)
     }
 
     init(iterations: Int, warmupIterations: Int, filter: String?, allowDebugBuild: Bool) throws {

--- a/Tests/BenchmarkTests/BenchmarkCommandTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkCommandTests.swift
@@ -18,34 +18,34 @@ import XCTest
 
 final class BenchmarkCommandTests: XCTestCase {
     func testAllowDebugBuild() throws {
-        AssertParse(["--allow-debug-build"]) { options in
-            XCTAssert(options.allowDebugBuild)
-        }
+         AssertParse(["--allow-debug-build"]) { settings in
+             XCTAssert(settings.allowDebugBuild)
+         }
     }
 
     func testDebugBuildError() {
-        // Note: this can only be tested in debug builds!
-        if testsAreRunningInDebugBuild {
-            do {
-                _ = try BenchmarkCommand.parse([])
-                XCTFail("Options successfully parsed when they should not have.")
-            } catch {
-                let message = BenchmarkCommand.message(for: error)
-                XCTAssert(message.starts(with: "Please build with optimizations enabled"), message)
-            }
-        }
+         // Note: this can only be tested in debug builds!
+         if testsAreRunningInDebugBuild {
+             do {
+                 _ = try BenchmarkCommand.parse([])
+                 XCTFail("Options successfully parsed when they should not have.")
+             } catch {
+                 let message = BenchmarkCommand.message(for: error)
+                 XCTAssert(message.starts(with: "Please build with optimizations enabled"), message)
+             }
+         }
     }
 
     func testParseFilter() throws {
-        AssertParse(["--filter", "bar", "--allow-debug-build"]) { options in
-            XCTAssertFalse(options.matches(suiteName: "foo", benchmarkName: "baz"))
-            XCTAssert(options.matches(suiteName: "foo", benchmarkName: "bar"))
+        AssertParse(["--filter", "bar", "--allow-debug-build"]) { settings in
+            XCTAssertFalse(settings.filter.matches(suiteName: "foo", benchmarkName: "baz"))
+            XCTAssert(settings.filter.matches(suiteName: "foo", benchmarkName: "bar"))
         }
 
-        AssertParse(["--filter", "foo/bar", "--allow-debug-build"]) { options in
-            XCTAssertFalse(options.matches(suiteName: "foo", benchmarkName: "baz"))
-            XCTAssertFalse(options.matches(suiteName: "foobar", benchmarkName: "baz"))
-            XCTAssert(options.matches(suiteName: "foo", benchmarkName: "bar"))
+        AssertParse(["--filter", "foo/bar", "--allow-debug-build"]) { settings in
+            XCTAssertFalse(settings.filter.matches(suiteName: "foo", benchmarkName: "baz"))
+            XCTAssertFalse(settings.filter.matches(suiteName: "foobar", benchmarkName: "baz"))
+            XCTAssert(settings.filter.matches(suiteName: "foo", benchmarkName: "bar"))
         }
     }
 
@@ -62,17 +62,19 @@ extension BenchmarkCommandTests {
         _ arguments: [String],
         file: StaticString = #file,
         line: UInt = #line,
-        closure: (BenchmarkCommand) -> Void
+        closure: (BenchmarkSettings) -> Void
     ) {
         let parsed: BenchmarkCommand
+        let settings: BenchmarkSettings
         do {
             parsed = try BenchmarkCommand.parse(arguments)
+            settings = try BenchmarkSettings(parsed.settings)
         } catch {
             let message = BenchmarkCommand.message(for: error)
             XCTFail("\"\(message)\" - \(error)", file: file, line: line)
             return
         }
-        closure(parsed)
+        closure(settings)
     }
 
     var testsAreRunningInDebugBuild: Bool {

--- a/Tests/BenchmarkTests/BenchmarkCommandTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkCommandTests.swift
@@ -49,10 +49,28 @@ final class BenchmarkCommandTests: XCTestCase {
         }
     }
 
+    func testParseIterations() throws {
+        AssertParse(["--iterations", "42", "--allow-debug-build"]) { settings in 
+            XCTAssertEqual(settings.iterations, 42)
+        }
+    }
+
+    func testParseZeroIterationsError() throws {
+         do {
+             _ = try BenchmarkCommand.parse(["--iterations", "0", "--allow-debug-build"])
+             XCTFail("Options successfully parsed when they should not have.")
+         } catch {
+             let message = BenchmarkCommand.message(for: error)
+             XCTAssert(message.starts(with: "Please make sure that number of iterations"), message)
+         }
+    }
+
     static var allTests = [
         ("testAllowDebugBuild", testAllowDebugBuild),
         ("testDebugBuildError", testDebugBuildError),
         ("testParseFilter", testParseFilter),
+        ("testParseIterations", testParseIterations),
+        // ("testParseZeroIterationsError", testParseZeroIterationsError),
     ]
 }
 

--- a/Tests/BenchmarkTests/BenchmarkCommandTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkCommandTests.swift
@@ -18,8 +18,12 @@ import XCTest
 
 final class BenchmarkCommandTests: XCTestCase {
     func testAllowDebugBuild() throws {
-        AssertParse(["--allow-debug-build"]) { settings in
-            XCTAssert(settings.allowDebugBuild)
+        if testsAreRunningInDebugBuild {
+            do {
+                _ = try BenchmarkCommand.parse(["--allow-debug-build"])
+            } catch {
+                XCTFail("--alow-debug-build should not crash when running in debug build")
+            }
         }
     }
 

--- a/Tests/BenchmarkTests/BenchmarkCommandTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkCommandTests.swift
@@ -18,22 +18,22 @@ import XCTest
 
 final class BenchmarkCommandTests: XCTestCase {
     func testAllowDebugBuild() throws {
-         AssertParse(["--allow-debug-build"]) { settings in
-             XCTAssert(settings.allowDebugBuild)
-         }
+        AssertParse(["--allow-debug-build"]) { settings in
+            XCTAssert(settings.allowDebugBuild)
+        }
     }
 
     func testDebugBuildError() {
-         // Note: this can only be tested in debug builds!
-         if testsAreRunningInDebugBuild {
-             do {
-                 _ = try BenchmarkCommand.parse([])
-                 XCTFail("Options successfully parsed when they should not have.")
-             } catch {
-                 let message = BenchmarkCommand.message(for: error)
-                 XCTAssert(message.starts(with: "Please build with optimizations enabled"), message)
-             }
-         }
+        // Note: this can only be tested in debug builds!
+        if testsAreRunningInDebugBuild {
+            do {
+                _ = try BenchmarkCommand.parse([])
+                XCTFail("Options successfully parsed when they should not have.")
+            } catch {
+                let message = BenchmarkCommand.message(for: error)
+                XCTAssert(message.starts(with: "Please build with optimizations enabled"), message)
+            }
+        }
     }
 
     func testParseFilter() throws {
@@ -50,35 +50,36 @@ final class BenchmarkCommandTests: XCTestCase {
     }
 
     func testParseIterations() throws {
-        AssertParse(["--iterations", "42", "--allow-debug-build"]) { settings in 
+        AssertParse(["--iterations", "42", "--allow-debug-build"]) { settings in
             XCTAssertEqual(settings.iterations, 42)
         }
     }
 
     func testParseZeroIterationsError() throws {
-         do {
-             _ = try BenchmarkCommand.parse(["--iterations", "0", "--allow-debug-build"])
-             XCTFail("Options successfully parsed when they should not have.")
-         } catch {
-             let message = BenchmarkCommand.message(for: error)
-             XCTAssert(message.starts(with: "Please make sure that number of iterations"), message)
-         }
+        do {
+            _ = try BenchmarkCommand.parse(["--iterations", "0", "--allow-debug-build"])
+            XCTFail("Options successfully parsed when they should not have.")
+        } catch {
+            let message = BenchmarkCommand.message(for: error)
+            XCTAssert(message.starts(with: "Please make sure that number of iterations"), message)
+        }
     }
 
     func testParseWarmupIterations() throws {
-        AssertParse(["--warmup-iterations", "42", "--allow-debug-build"]) { settings in 
+        AssertParse(["--warmup-iterations", "42", "--allow-debug-build"]) { settings in
             XCTAssertEqual(settings.warmupIterations, 42)
         }
     }
 
     func testParseNegativeWarmupIterationsError() throws {
-         do {
-             _ = try BenchmarkCommand.parse(["--warmup-iterations", "-1", "--allow-debug-build"])
-             XCTFail("Options successfully parsed when they should not have.")
-         } catch {
-             let message = BenchmarkCommand.message(for: error)
-             XCTAssert(message.starts(with: "Please make sure that number of warmup iterations"), message)
-         }
+        do {
+            _ = try BenchmarkCommand.parse(["--warmup-iterations", "-1", "--allow-debug-build"])
+            XCTFail("Options successfully parsed when they should not have.")
+        } catch {
+            let message = BenchmarkCommand.message(for: error)
+            XCTAssert(
+                message.starts(with: "Please make sure that number of warmup iterations"), message)
+        }
     }
 
     static var allTests = [

--- a/Tests/BenchmarkTests/BenchmarkCommandTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkCommandTests.swift
@@ -71,17 +71,6 @@ final class BenchmarkCommandTests: XCTestCase {
         }
     }
 
-    func testParseNegativeWarmupIterationsError() throws {
-        do {
-            _ = try BenchmarkCommand.parse(["--warmup-iterations", "-1", "--allow-debug-build"])
-            XCTFail("Options successfully parsed when they should not have.")
-        } catch {
-            let message = BenchmarkCommand.message(for: error)
-            XCTAssert(
-                message.starts(with: "Please make sure that number of warmup iterations"), message)
-        }
-    }
-
     static var allTests = [
         ("testAllowDebugBuild", testAllowDebugBuild),
         ("testDebugBuildError", testDebugBuildError),

--- a/Tests/BenchmarkTests/BenchmarkCommandTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkCommandTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 @testable import Benchmark
 
-final class BenchmarkRunnerOptionsTests: XCTestCase {
+final class BenchmarkCommandTests: XCTestCase {
     func testAllowDebugBuild() throws {
         AssertParse(["--allow-debug-build"]) { options in
             XCTAssert(options.allowDebugBuild)
@@ -27,10 +27,10 @@ final class BenchmarkRunnerOptionsTests: XCTestCase {
         // Note: this can only be tested in debug builds!
         if testsAreRunningInDebugBuild {
             do {
-                _ = try BenchmarkRunnerOptions.parse([])
+                _ = try BenchmarkCommand.parse([])
                 XCTFail("Options successfully parsed when they should not have.")
             } catch {
-                let message = BenchmarkRunnerOptions.message(for: error)
+                let message = BenchmarkCommand.message(for: error)
                 XCTAssert(message.starts(with: "Please build with optimizations enabled"), message)
             }
         }
@@ -56,19 +56,19 @@ final class BenchmarkRunnerOptionsTests: XCTestCase {
     ]
 }
 
-extension BenchmarkRunnerOptionsTests {
+extension BenchmarkCommandTests {
     /// Parse `arguments` and call `closure` with the resulting options.
     func AssertParse(
         _ arguments: [String],
         file: StaticString = #file,
         line: UInt = #line,
-        closure: (BenchmarkRunnerOptions) -> Void
+        closure: (BenchmarkCommand) -> Void
     ) {
-        let parsed: BenchmarkRunnerOptions
+        let parsed: BenchmarkCommand
         do {
-            parsed = try BenchmarkRunnerOptions.parse(arguments)
+            parsed = try BenchmarkCommand.parse(arguments)
         } catch {
-            let message = BenchmarkRunnerOptions.message(for: error)
+            let message = BenchmarkCommand.message(for: error)
             XCTFail("\"\(message)\" - \(error)", file: file, line: line)
             return
         }

--- a/Tests/BenchmarkTests/BenchmarkCommandTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkCommandTests.swift
@@ -65,12 +65,29 @@ final class BenchmarkCommandTests: XCTestCase {
          }
     }
 
+    func testParseWarmupIterations() throws {
+        AssertParse(["--warmup-iterations", "42", "--allow-debug-build"]) { settings in 
+            XCTAssertEqual(settings.warmupIterations, 42)
+        }
+    }
+
+    func testParseNegativeWarmupIterationsError() throws {
+         do {
+             _ = try BenchmarkCommand.parse(["--warmup-iterations", "-1", "--allow-debug-build"])
+             XCTFail("Options successfully parsed when they should not have.")
+         } catch {
+             let message = BenchmarkCommand.message(for: error)
+             XCTAssert(message.starts(with: "Please make sure that number of warmup iterations"), message)
+         }
+    }
+
     static var allTests = [
         ("testAllowDebugBuild", testAllowDebugBuild),
         ("testDebugBuildError", testDebugBuildError),
         ("testParseFilter", testParseFilter),
         ("testParseIterations", testParseIterations),
-        // ("testParseZeroIterationsError", testParseZeroIterationsError),
+        ("testParseZeroIterationsError", testParseZeroIterationsError),
+        ("testParseWarmupIterations", testParseWarmupIterations),
     ]
 }
 

--- a/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
@@ -18,18 +18,18 @@ import XCTest
 
 final class BenchmarkRunnerTests: XCTestCase {
     func testFilterBenchmarksSuffix() throws {
-        let options = try BenchmarkRunnerOptions(filter: "b1")
-        XCTAssertEqual(Set(["suite1/b1", "suite2/b1"]), runBenchmarks(options: options))
+        let command = try BenchmarkCommand(filter: "b1")
+        XCTAssertEqual(Set(["suite1/b1", "suite2/b1"]), runBenchmarks(command: command))
     }
 
     func testFilterBenchmarksSuiteName() throws {
-        let options = try BenchmarkRunnerOptions(filter: "suite1")
-        XCTAssertEqual(Set(["suite1/b1", "suite1/b2"]), runBenchmarks(options: options))
+        let command = try BenchmarkCommand(filter: "suite1")
+        XCTAssertEqual(Set(["suite1/b1", "suite1/b2"]), runBenchmarks(command: command))
     }
 
     func testFilterBenchmarksFullName() throws {
-        let options = try BenchmarkRunnerOptions(filter: "suite1/b1")
-        XCTAssertEqual(Set(["suite1/b1"]), runBenchmarks(options: options))
+        let command = try BenchmarkCommand(filter: "suite1/b1")
+        XCTAssertEqual(Set(["suite1/b1"]), runBenchmarks(command: command))
     }
 
     static var allTests = [
@@ -40,9 +40,9 @@ final class BenchmarkRunnerTests: XCTestCase {
 }
 
 extension BenchmarkRunnerTests {
-    /// Builds and runs a few suites of benchmarks with provided options; returns the set of
+    /// Builds and runs a few suites of benchmarks with provided command; returns the set of
     /// benchmark names that were run.
-    func runBenchmarks(options: BenchmarkRunnerOptions) -> Set<String> {
+    func runBenchmarks(command: BenchmarkCommand) -> Set<String> {
         let suite1 = BenchmarkSuite(name: "suite1")
         let suite2 = BenchmarkSuite(name: "suite2")
 
@@ -57,7 +57,7 @@ extension BenchmarkRunnerTests {
             suites: [suite1, suite2],
             reporter: BlackHoleReporter())
 
-        runner.run(options: options)
+        runner.run(command: command)
         return benchmarksRun
     }
 }

--- a/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
@@ -18,18 +18,18 @@ import XCTest
 
 final class BenchmarkRunnerTests: XCTestCase {
     func testFilterBenchmarksSuffix() throws {
-        let command = try BenchmarkCommand(filter: "b1")
-        XCTAssertEqual(Set(["suite1/b1", "suite2/b1"]), runBenchmarks(command: command))
+        let settings: [BenchmarkSetting] = [.iterations(1), .filter("b1")]
+        XCTAssertEqual(Set(["suite1/b1", "suite2/b1"]), runBenchmarks(settings: settings))
     }
 
     func testFilterBenchmarksSuiteName() throws {
-        let command = try BenchmarkCommand(filter: "suite1")
-        XCTAssertEqual(Set(["suite1/b1", "suite1/b2"]), runBenchmarks(command: command))
+        let settings: [BenchmarkSetting] = [.iterations(1), .filter("suite1")]
+        XCTAssertEqual(Set(["suite1/b1", "suite1/b2"]), runBenchmarks(settings: settings))
     }
 
     func testFilterBenchmarksFullName() throws {
-        let command = try BenchmarkCommand(filter: "suite1/b1")
-        XCTAssertEqual(Set(["suite1/b1"]), runBenchmarks(command: command))
+        let settings: [BenchmarkSetting] = [.iterations(1), .filter("suite1/b1")]
+        XCTAssertEqual(Set(["suite1/b1"]), runBenchmarks(settings: settings))
     }
 
     static var allTests = [
@@ -40,9 +40,9 @@ final class BenchmarkRunnerTests: XCTestCase {
 }
 
 extension BenchmarkRunnerTests {
-    /// Builds and runs a few suites of benchmarks with provided command; returns the set of
+    /// Builds and runs a few suites of benchmarks with provided settings; returns the set of
     /// benchmark names that were run.
-    func runBenchmarks(command: BenchmarkCommand) -> Set<String> {
+    func runBenchmarks(settings: [BenchmarkSetting]) -> Set<String> {
         let suite1 = BenchmarkSuite(name: "suite1")
         let suite2 = BenchmarkSuite(name: "suite2")
 
@@ -55,9 +55,14 @@ extension BenchmarkRunnerTests {
 
         var runner = BenchmarkRunner(
             suites: [suite1, suite2],
+            settings: settings,
             reporter: BlackHoleReporter())
 
-        runner.run(command: command)
-        return benchmarksRun
+        do {
+            try runner.run()
+            return benchmarksRun
+        } catch {
+            return Set<String>()
+        }
     }
 }

--- a/Tests/BenchmarkTests/BenchmarkSettingTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkSettingTests.swift
@@ -18,8 +18,11 @@ import XCTest
 
 final class BenchmarkSettingTests: XCTestCase {
 
-    func assertNumberOfIterations(suite: BenchmarkSuite, counts expected: [Int]) throws {
-        let settings: [BenchmarkSetting] = [.iterations(100000)]
+    func assertNumberOfIterations(
+        suite: BenchmarkSuite,
+        counts expected: [Int],
+        cli settings: [BenchmarkSetting] = [.iterations(100000)]
+    ) throws {
         let reporter = BlackHoleReporter()
         var runner = BenchmarkRunner(suites: [suite], settings: settings, reporter: reporter)
         do {
@@ -64,10 +67,50 @@ final class BenchmarkSettingTests: XCTestCase {
         try assertNumberOfIterations(suite: suite, counts: [42, 21])
     }
 
+    func testCliSetting() throws {
+        let cli: [BenchmarkSetting] = [.iterations(1)]
+        let suite = BenchmarkSuite(name: "Test") { suite in
+            suite.benchmark("a") {}
+            suite.benchmark("b") {}
+        }
+        try assertNumberOfIterations(suite: suite, counts: [1, 1], cli: cli)
+    }
+
+    func testSuiteOverridesCliSetting() throws {
+        let cli: [BenchmarkSetting] = [.iterations(1)]
+        let suite = BenchmarkSuite(name: "Test", settings: .iterations(2)) { suite in
+            suite.benchmark("a") {}
+            suite.benchmark("b") {}
+        }
+        try assertNumberOfIterations(suite: suite, counts: [2, 2], cli: cli)
+    }
+
+    func testBenchmarkOverridesCliSetting() throws {
+        let cli: [BenchmarkSetting] = [.iterations(1)]
+        let suite = BenchmarkSuite(name: "Test") { suite in
+            suite.benchmark("a") {}
+            suite.benchmark("b", settings: .iterations(2)) {}
+        }
+        try assertNumberOfIterations(suite: suite, counts: [1, 2], cli: cli)
+    }
+
+    func testBenchmarkAndSuiteOverridesCliSetting() throws {
+        let cli: [BenchmarkSetting] = [.iterations(1)]
+        let suite = BenchmarkSuite(name: "Test", settings: .iterations(2)) { suite in
+            suite.benchmark("a") {}
+            suite.benchmark("b", settings: .iterations(3)) {}
+        }
+        try assertNumberOfIterations(suite: suite, counts: [2, 3], cli: cli)
+    }
+
     static var allTests = [
         ("testDefaultSetting", testDefaultSetting),
         ("testSuiteSetting", testSuiteSetting),
         ("testBenchmarkSetting", testBenchmarkSetting),
         ("testBenchmarkSettingOverridesSuiteSetting", testBenchmarkSettingOverridesSuiteSetting),
+        ("testCliSetting", testCliSetting),
+        ("testSuiteOverridesCliSetting", testSuiteOverridesCliSetting),
+        ("testBenchmarkOverridesCliSetting", testBenchmarkOverridesCliSetting),
+        ("testBenchmarkAndSuiteOverridesCliSetting", testBenchmarkAndSuiteOverridesCliSetting),
     ]
 }

--- a/Tests/BenchmarkTests/BenchmarkSettingTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkSettingTests.swift
@@ -19,14 +19,17 @@ import XCTest
 final class BenchmarkSettingTests: XCTestCase {
 
     func assertNumberOfIterations(suite: BenchmarkSuite, counts expected: [Int]) throws {
-        let options = try BenchmarkCommand(filter: ".*")
-        var reporter = BlackHoleReporter()
-        var runner = BenchmarkRunner(suites: [suite], reporter: reporter)
-        runner.run(command: options)
-
-        XCTAssertEqual(runner.results.count, expected.count)
-        let counts = Array(runner.results.map(\.measurements.count))
-        XCTAssertEqual(counts, expected)
+        let settings: [BenchmarkSetting] = [.iterations(100000)]
+        let reporter = BlackHoleReporter()
+        var runner = BenchmarkRunner(suites: [suite], settings: settings, reporter: reporter)
+        do { 
+            try runner.run()
+            XCTAssertEqual(runner.results.count, expected.count)
+            let counts = Array(runner.results.map(\.measurements.count))
+            XCTAssertEqual(counts, expected)
+        } catch {
+            XCTAssertTrue(false)
+        }
     }
 
     func testDefaultSetting() throws {

--- a/Tests/BenchmarkTests/BenchmarkSettingTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkSettingTests.swift
@@ -19,10 +19,10 @@ import XCTest
 final class BenchmarkSettingTests: XCTestCase {
 
     func assertNumberOfIterations(suite: BenchmarkSuite, counts expected: [Int]) throws {
-        let options = try BenchmarkRunnerOptions(filter: ".*")
+        let options = try BenchmarkCommand(filter: ".*")
         var reporter = BlackHoleReporter()
         var runner = BenchmarkRunner(suites: [suite], reporter: reporter)
-        runner.run(options: options)
+        runner.run(command: options)
 
         XCTAssertEqual(runner.results.count, expected.count)
         let counts = Array(runner.results.map(\.measurements.count))

--- a/Tests/BenchmarkTests/BenchmarkSettingTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkSettingTests.swift
@@ -22,7 +22,7 @@ final class BenchmarkSettingTests: XCTestCase {
         let settings: [BenchmarkSetting] = [.iterations(100000)]
         let reporter = BlackHoleReporter()
         var runner = BenchmarkRunner(suites: [suite], settings: settings, reporter: reporter)
-        do { 
+        do {
             try runner.run()
             XCTAssertEqual(runner.results.count, expected.count)
             let counts = Array(runner.results.map(\.measurements.count))

--- a/Tests/BenchmarkTests/XCTTestManifests.swift
+++ b/Tests/BenchmarkTests/XCTTestManifests.swift
@@ -17,7 +17,7 @@ import XCTest
 #if !canImport(ObjectiveC)
     public func allTests() -> [XCTestCaseEntry] {
         return [
-            testCase(BenchmarkRunnerOptionsTests.allTests),
+            testCase(BenchmarkCommandTests.allTests),
             testCase(BenchmarkRunnerTests.allTests),
             testCase(BenchmarkSettingTests.allTests),
             testCase(StatsTests.allTests),


### PR DESCRIPTION
This PR makes command-line settings play nicely with multi-level settings. It adds a new level (highlighted bold):

* Default settings
* **Command-line settings**
* Suite settings
* Benchmarks settings

Additionally, two new command-line flags are introduced:

* `--iterations n` to override default number of iterations
* `--warmup-iterations n` to override default number of warm-up iterations