### PR TITLE
Fix #8: automatically detect a reasonable number of iterations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Example:
 import Benchmark
 
 benchmark("add string reserved capacity") {
-    var x2: String = ""
-    x2.reserveCapacity(2000)
+    var x: String = ""
+    x.reserveCapacity(2000)
     for _ in 1...1000 {
-        x2 += "hi"
+        x += "hi"
     }
 }
 
@@ -26,14 +26,20 @@ Example:
 
 ```bash
 $ swift run -c release BenchmarkMinimalExample -h
-USAGE: benchmark-runner-options --filter <filter> [--allow-debug-build]
+[3/3] Linking BenchmarkMinimalExample
+USAGE: benchmark-command [--allow-debug-build] [--filter <filter>] [--iterations <iterations>] [--warmup-iterations <warmup-iterations>] [--min-time <min-time>] [--max-iterations <max-iterations>]
 
 OPTIONS:
-  --filter <filter>       Run only benchmarks whose names match the regular expression.
   --allow-debug-build     Overrides check to verify optimized build.
+  --filter <filter>       Run only benchmarks whose names match the regular expression.
+  --iterations <iterations>
+                          Number of iterations to run.
+  --warmup-iterations <warmup-iterations>
+                          Number of warm-up iterations to run.
+  --min-time <min-time>   Minimal time to run when automatically detecting number iterations.
+  --max-iterations <max-iterations>
+                          Maximum number of iterations to run when automatically detecting number iterations.
   -h, --help              Show help information.
-
-$
 ```
 
 For more examples, see Sources/BenchmarkMinimalExample and

--- a/Sources/Benchmark/BenchmarkCommand.swift
+++ b/Sources/Benchmark/BenchmarkCommand.swift
@@ -49,7 +49,7 @@ internal struct BenchmarkCommand: ParsableCommand {
             result.append(.warmupIterations(value))
         }
         if let value = minTime {
-            result.append(.minTime(value))
+            result.append(.minTime(seconds: value))
         }
         if let value = maxIterations {
             result.append(.maxIterations(value))
@@ -78,7 +78,8 @@ internal struct BenchmarkCommand: ParsableCommand {
             throw ValidationError(positiveNumberError(flag: "--max-iterations", of: "integer"))
         }
         if minTime != nil && minTime! <= 0 {
-            throw ValidationError(positiveNumberError(flag: "--min-time", of: "floating point number"))
+            throw ValidationError(
+                positiveNumberError(flag: "--min-time", of: "floating point number"))
         }
     }
 

--- a/Sources/Benchmark/BenchmarkCommand.swift
+++ b/Sources/Benchmark/BenchmarkCommand.swift
@@ -78,7 +78,7 @@ internal struct BenchmarkCommand: ParsableCommand {
             throw ValidationError(positiveNumberError(flag: "--max-iterations", of: "integer"))
         }
         if minTime != nil && minTime! <= 0 {
-            throw ValidationError(positiveNumberError(flag: "--min-time", of: "floating"))
+            throw ValidationError(positiveNumberError(flag: "--min-time", of: "floating point number"))
         }
     }
 
@@ -92,6 +92,6 @@ internal struct BenchmarkCommand: ParsableCommand {
     }
 
     func positiveNumberError(flag: String, of type: String) -> String {
-        return "Value provided via \(flag) must be a positive \(type) number."
+        return "Value provided via \(flag) must be a positive \(type)."
     }
 }

--- a/Sources/Benchmark/BenchmarkCommand.swift
+++ b/Sources/Benchmark/BenchmarkCommand.swift
@@ -69,7 +69,16 @@ internal struct BenchmarkCommand: ParsableCommand {
             throw ValidationError(debugBuildErrorMessage)
         }
         if iterations != nil && iterations! <= 0 {
-            throw ValidationError(iterationsErrorMessage)
+            throw ValidationError(positiveNumberError(flag: "--iterations", of: "integer"))
+        }
+        if warmupIterations != nil && warmupIterations! <= 0 {
+            throw ValidationError(positiveNumberError(flag: "--warmup-iterations", of: "integer"))
+        }
+        if maxIterations != nil && maxIterations! <= 0 {
+            throw ValidationError(positiveNumberError(flag: "--max-iterations", of: "integer"))
+        }
+        if minTime != nil && minTime! <= 0 {
+            throw ValidationError(positiveNumberError(flag: "--min-time", of: "floating"))
         }
     }
 
@@ -82,7 +91,7 @@ internal struct BenchmarkCommand: ParsableCommand {
         """
     }
 
-    var iterationsErrorMessage: String {
-        "Please make sure that number of iterations is a positive integer number."
+    func positiveNumberError(flag: String, of type: String) -> String {
+        return "Value provided via \(flag) must be a positive \(type) number."
     }
 }

--- a/Sources/Benchmark/BenchmarkCommand.swift
+++ b/Sources/Benchmark/BenchmarkCommand.swift
@@ -29,17 +29,32 @@ internal struct BenchmarkCommand: ParsableCommand {
     @Option(help: "Number of warm-up iterations to run.")
     var warmupIterations: Int?
 
+    @Option(help: "Minimal time to run when automatically detecting number iterations.")
+    var minTime: Double?
+
+    @Option(
+        help: "Maximum number of iterations to run when automatically detecting number iterations.")
+    var maxIterations: Int?
+
     var settings: [BenchmarkSetting] {
         var result: [BenchmarkSetting] = []
-        if filter != nil {
-            result.append(.filter(filter!))
+
+        if let value = filter {
+            result.append(.filter(value))
         }
-        if iterations != nil {
-            result.append(.iterations(iterations!))
+        if let value = iterations {
+            result.append(.iterations(value))
         }
-        if warmupIterations != nil {
-            result.append(.warmupIterations(warmupIterations!))
+        if let value = warmupIterations {
+            result.append(.warmupIterations(value))
         }
+        if let value = minTime {
+            result.append(.minTime(value))
+        }
+        if let value = maxIterations {
+            result.append(.maxIterations(value))
+        }
+
         return result
     }
 

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -78,7 +78,7 @@ public struct BenchmarkRunner {
         let iters = measurements.count
 
         // See how much iterations should be increased by.
-        // Note: Avoid division by zero with max(seconds, 1ns)
+        // Note: Avoid division by zero with max(timeInSeconds, 1ns)
         let timeInSeconds = measurements.reduce(0, +) / 1000000000.0
         var multiplier: Double = minTime * 1.4 / max(timeInSeconds, 1e-9)
 
@@ -103,7 +103,7 @@ public struct BenchmarkRunner {
     }
 
     /// Heuristic when to stop looking for new number of iterations, ported from google/benchmark.
-    func shouldReportResults(_ measurements: [Double], settings: BenchmarkSettings) -> Bool {
+    func hasCollectedEnoughData(_ measurements: [Double], settings: BenchmarkSettings) -> Bool {
         let tooManyIterations = measurements.count > settings.maxIterations
         let timeInSeconds = measurements.reduce(0, +) / 1000000000.0
         let timeIsLargeEnough = timeInSeconds > settings.minTime
@@ -118,7 +118,7 @@ public struct BenchmarkRunner {
 
         while true {
             measurements = doNIterations(n, benchmark: benchmark, suite: suite)
-            if n != 1 && shouldReportResults(measurements, settings: settings) { break }
+            if n != 1 && hasCollectedEnoughData(measurements, settings: settings) { break }
             n = predictNumberOfIterationsNeeded(measurements, settings: settings)
         }
 

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -51,8 +51,8 @@ public struct BenchmarkRunner {
 
         reporter.report(running: benchmark.name, suite: suite.name)
 
-        if settings.warmupIterations > 0 {
-            let _ = doNIterations(settings.warmupIterations, benchmark: benchmark, suite: suite)
+        if let n = settings.warmupIterations {
+            let _ = doNIterations(n, benchmark: benchmark, suite: suite)
         }
 
         var measurements: [Double] = []
@@ -118,7 +118,7 @@ public struct BenchmarkRunner {
 
         while true {
             measurements = doNIterations(n, benchmark: benchmark, suite: suite)
-            if shouldReportResults(measurements, settings: settings) { break }
+            if n != 1 && shouldReportResults(measurements, settings: settings) { break }
             n = predictNumberOfIterationsNeeded(measurements, settings: settings)
         }
 

--- a/Sources/Benchmark/BenchmarkSetting.swift
+++ b/Sources/Benchmark/BenchmarkSetting.swift
@@ -75,5 +75,5 @@ struct BenchmarkSettings {
 
 let defaultSettings: [BenchmarkSetting] = [
     .maxIterations(1_000_000_000),
-    .minTime(1.0),
+    .minTime(seconds: 1.0),
 ]

--- a/Sources/Benchmark/BenchmarkSetting.swift
+++ b/Sources/Benchmark/BenchmarkSetting.swift
@@ -22,7 +22,7 @@ public enum BenchmarkSetting {
 
 struct BenchmarkSettings {
     let iterations: Int?
-    let warmupIterations: Int
+    let warmupIterations: Int?
     let maxIterations: Int
     let filter: BenchmarkFilter
     let minTime: Double
@@ -33,7 +33,7 @@ struct BenchmarkSettings {
 
     init(_ settings: [BenchmarkSetting]) throws {
         var iterations: Int? = nil
-        var warmupIterations: Int = -1
+        var warmupIterations: Int? = nil
         var maxIterations: Int = -1
         var filter: String? = nil
         var minTime: Double = -1
@@ -62,7 +62,7 @@ struct BenchmarkSettings {
     }
 
     init(
-        iterations: Int?, warmupIterations: Int, maxIterations: Int, filter: String?,
+        iterations: Int?, warmupIterations: Int?, maxIterations: Int, filter: String?,
         minTime: Double
     ) throws {
         self.iterations = iterations
@@ -74,7 +74,6 @@ struct BenchmarkSettings {
 }
 
 let defaultSettings: [BenchmarkSetting] = [
-    .warmupIterations(1),
     .maxIterations(1_000_000_000),
     .minTime(1.0),
 ]

--- a/Sources/Benchmark/BenchmarkSetting.swift
+++ b/Sources/Benchmark/BenchmarkSetting.swift
@@ -17,7 +17,7 @@ public enum BenchmarkSetting {
     case maxIterations(Int)
     case warmupIterations(Int)
     case filter(String)
-    case minTime(Double)
+    case minTime(seconds: Double)
 }
 
 struct BenchmarkSettings {

--- a/Sources/Benchmark/BenchmarkSetting.swift
+++ b/Sources/Benchmark/BenchmarkSetting.swift
@@ -14,23 +14,29 @@
 
 public enum BenchmarkSetting {
     case iterations(Int)
+    case maxIterations(Int)
     case warmupIterations(Int)
     case filter(String)
+    case minTime(Double)
 }
 
 struct BenchmarkSettings {
-    let iterations: Int
+    let iterations: Int?
     let warmupIterations: Int
+    let maxIterations: Int
     let filter: BenchmarkFilter
+    let minTime: Double
 
     init(_ settings: [[BenchmarkSetting]]) throws {
         try self.init(Array(settings.joined()))
     }
 
     init(_ settings: [BenchmarkSetting]) throws {
-        var iterations: Int = -1
+        var iterations: Int? = nil
         var warmupIterations: Int = -1
+        var maxIterations: Int = -1
         var filter: String? = nil
+        var minTime: Double = -1
 
         for setting in settings {
             switch setting {
@@ -40,23 +46,35 @@ struct BenchmarkSettings {
                 warmupIterations = value
             case .filter(let value):
                 filter = value
+            case .maxIterations(let value):
+                maxIterations = value
+            case .minTime(let value):
+                minTime = value
             }
         }
 
         try self.init(
             iterations: iterations,
             warmupIterations: warmupIterations,
-            filter: filter)
+            maxIterations: maxIterations,
+            filter: filter,
+            minTime: minTime)
     }
 
-    init(iterations: Int, warmupIterations: Int, filter: String?) throws {
+    init(
+        iterations: Int?, warmupIterations: Int, maxIterations: Int, filter: String?,
+        minTime: Double
+    ) throws {
         self.iterations = iterations
         self.warmupIterations = warmupIterations
+        self.maxIterations = maxIterations
         self.filter = try BenchmarkFilter(filter)
+        self.minTime = minTime
     }
 }
 
 let defaultSettings: [BenchmarkSetting] = [
-    .iterations(100000),
     .warmupIterations(1),
+    .maxIterations(1_000_000_000),
+    .minTime(1.0),
 ]

--- a/Tests/BenchmarkTests/BenchmarkCommandTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkCommandTests.swift
@@ -60,15 +60,9 @@ final class BenchmarkCommandTests: XCTestCase {
     }
 
     func testParseZeroIterationsError() throws {
-        do {
-            _ = try BenchmarkCommand.parse(["--iterations", "0", "--allow-debug-build"])
-            XCTFail("Options successfully parsed when they should not have.")
-        } catch {
-            let message = BenchmarkCommand.message(for: error)
-            XCTAssert(
-                message.starts(
-                    with: "Value provided via --iterations must be a positive integer."))
-        }
+        AssertFailsToParse(
+            ["--iterations", "0", "--allow-debug-build"],
+            with: "Value provided via --iterations must be a positive integer.")
     }
 
     func testParseWarmupIterations() throws {
@@ -78,17 +72,9 @@ final class BenchmarkCommandTests: XCTestCase {
     }
 
     func testParseZeroWarmupIterationsError() throws {
-        do {
-            _ = try BenchmarkCommand.parse(["--warmup-iterations", "0", "--allow-debug-build"])
-            XCTFail("Options successfully parsed when they should not have.")
-        } catch {
-            let message = BenchmarkCommand.message(for: error)
-            XCTAssert(
-                message.starts(
-                    with:
-                        "Value provided via --warmup-iterations must be a positive integer.")
-            )
-        }
+        AssertFailsToParse(
+            ["--warmup-iterations", "0", "--allow-debug-build"],
+            with: "Value provided via --warmup-iterations must be a positive integer.")
     }
 
     func testParseMaxIterations() throws {
@@ -98,15 +84,9 @@ final class BenchmarkCommandTests: XCTestCase {
     }
 
     func testParseZeroMaxIterationsError() throws {
-        do {
-            _ = try BenchmarkCommand.parse(["--max-iterations", "0", "--allow-debug-build"])
-            XCTFail("Options successfully parsed when they should not have.")
-        } catch {
-            let message = BenchmarkCommand.message(for: error)
-            XCTAssert(
-                message.starts(
-                    with: "Value provided via --max-iterations must be a positive integer."))
-        }
+        AssertFailsToParse(
+            ["--warmup-iterations", "0", "--allow-debug-build"],
+            with: "Value provided via --max-iterations must be a positive integer.")
     }
 
     func testParseMinTime() throws {
@@ -116,16 +96,9 @@ final class BenchmarkCommandTests: XCTestCase {
     }
 
     func testParseZeroMinTimeError() throws {
-        do {
-            _ = try BenchmarkCommand.parse(["--min-time", "0", "--allow-debug-build"])
-            XCTFail("Options successfully parsed when they should not have.")
-        } catch {
-            let message = BenchmarkCommand.message(for: error)
-            XCTAssert(
-                message.starts(
-                    with: "Value provided via --min-time must be a positive floating point number.")
-            )
-        }
+        AssertFailsToParse(
+            ["--min-time", "0", "--allow-debug-build"],
+            with: "Value provided via --min-time must be a positive floating point number.")
     }
 
     static var allTests = [
@@ -162,6 +135,16 @@ extension BenchmarkCommandTests {
             return
         }
         closure(settings)
+    }
+
+    func AssertFailsToParse(_ arguments: [String], with message: String) {
+        do {
+            _ = try BenchmarkCommand.parse(arguments)
+            XCTFail("Options successfully parsed when they should not have.")
+        } catch {
+            let message = BenchmarkCommand.message(for: error)
+            XCTAssert(message.starts(with: message))
+        }
     }
 
     var testsAreRunningInDebugBuild: Bool {

--- a/Tests/BenchmarkTests/BenchmarkCommandTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkCommandTests.swift
@@ -67,7 +67,7 @@ final class BenchmarkCommandTests: XCTestCase {
             let message = BenchmarkCommand.message(for: error)
             XCTAssert(
                 message.starts(
-                    with: "Value provided via --iterations must be a positive integer number."))
+                    with: "Value provided via --iterations must be a positive integer."))
         }
     }
 
@@ -86,7 +86,7 @@ final class BenchmarkCommandTests: XCTestCase {
             XCTAssert(
                 message.starts(
                     with:
-                        "Value provided via --warmup-iterations must be a positive integer number.")
+                        "Value provided via --warmup-iterations must be a positive integer.")
             )
         }
     }
@@ -105,7 +105,7 @@ final class BenchmarkCommandTests: XCTestCase {
             let message = BenchmarkCommand.message(for: error)
             XCTAssert(
                 message.starts(
-                    with: "Value provided via --max-iterations must be a positive integer number."))
+                    with: "Value provided via --max-iterations must be a positive integer."))
         }
     }
 
@@ -123,7 +123,8 @@ final class BenchmarkCommandTests: XCTestCase {
             let message = BenchmarkCommand.message(for: error)
             XCTAssert(
                 message.starts(
-                    with: "Value provided via --min-time must be a positive floating number."))
+                    with: "Value provided via --min-time must be a positive floating point number.")
+            )
         }
     }
 

--- a/Tests/BenchmarkTests/BenchmarkCommandTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkCommandTests.swift
@@ -65,13 +65,65 @@ final class BenchmarkCommandTests: XCTestCase {
             XCTFail("Options successfully parsed when they should not have.")
         } catch {
             let message = BenchmarkCommand.message(for: error)
-            XCTAssert(message.starts(with: "Please make sure that number of iterations"), message)
+            XCTAssert(
+                message.starts(
+                    with: "Value provided via --iterations must be a positive integer number."))
         }
     }
 
     func testParseWarmupIterations() throws {
         AssertParse(["--warmup-iterations", "42", "--allow-debug-build"]) { settings in
             XCTAssertEqual(settings.warmupIterations, 42)
+        }
+    }
+
+    func testParseZeroWarmupIterationsError() throws {
+        do {
+            _ = try BenchmarkCommand.parse(["--warmup-iterations", "0", "--allow-debug-build"])
+            XCTFail("Options successfully parsed when they should not have.")
+        } catch {
+            let message = BenchmarkCommand.message(for: error)
+            XCTAssert(
+                message.starts(
+                    with:
+                        "Value provided via --warmup-iterations must be a positive integer number.")
+            )
+        }
+    }
+
+    func testParseMaxIterations() throws {
+        AssertParse(["--max-iterations", "42", "--allow-debug-build"]) { settings in
+            XCTAssertEqual(settings.maxIterations, 42)
+        }
+    }
+
+    func testParseZeroMaxIterationsError() throws {
+        do {
+            _ = try BenchmarkCommand.parse(["--max-iterations", "0", "--allow-debug-build"])
+            XCTFail("Options successfully parsed when they should not have.")
+        } catch {
+            let message = BenchmarkCommand.message(for: error)
+            XCTAssert(
+                message.starts(
+                    with: "Value provided via --max-iterations must be a positive integer number."))
+        }
+    }
+
+    func testParseMinTime() throws {
+        AssertParse(["--min-time", "42", "--allow-debug-build"]) { settings in
+            XCTAssertEqual(settings.minTime, 42)
+        }
+    }
+
+    func testParseZeroMinTimeError() throws {
+        do {
+            _ = try BenchmarkCommand.parse(["--min-time", "0", "--allow-debug-build"])
+            XCTFail("Options successfully parsed when they should not have.")
+        } catch {
+            let message = BenchmarkCommand.message(for: error)
+            XCTAssert(
+                message.starts(
+                    with: "Value provided via --min-time must be a positive floating number."))
         }
     }
 
@@ -82,6 +134,11 @@ final class BenchmarkCommandTests: XCTestCase {
         ("testParseIterations", testParseIterations),
         ("testParseZeroIterationsError", testParseZeroIterationsError),
         ("testParseWarmupIterations", testParseWarmupIterations),
+        ("testParseZeroWarmupIterationsError", testParseZeroWarmupIterationsError),
+        ("testParseMaxIterations", testParseWarmupIterations),
+        ("testParseZeroMaxIterationsError", testParseZeroWarmupIterationsError),
+        ("testParseMinTime", testParseMinTime),
+        ("testParseZeroMinTimeError", testParseZeroMinTimeError),
     ]
 }
 


### PR DESCRIPTION
This PR adopts the heuristic from google/benchmark to automatically
detect a statistically significant number of benchmark iterations
based on emperical results of running a few iterations at a time.