### PR TITLE
Test cleanup; just let it throw.

### DIFF
--- a/Tests/BenchmarkTests/BenchmarkSettingTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkSettingTests.swift
@@ -25,14 +25,11 @@ final class BenchmarkSettingTests: XCTestCase {
     ) throws {
         let reporter = BlackHoleReporter()
         var runner = BenchmarkRunner(suites: [suite], settings: settings, reporter: reporter)
-        do {
-            try runner.run()
-            XCTAssertEqual(runner.results.count, expected.count)
-            let counts = Array(runner.results.map(\.measurements.count))
-            XCTAssertEqual(counts, expected)
-        } catch {
-            XCTAssertTrue(false)
-        }
+
+        try runner.run()
+        XCTAssertEqual(runner.results.count, expected.count)
+        let counts = Array(runner.results.map(\.measurements.count))
+        XCTAssertEqual(counts, expected)
     }
 
     func testDefaultSetting() throws {


### PR DESCRIPTION
Previously, if there was a test failure, you'd get an XCTest failure, but you
would not get to see the message / etc. Instead now, the error will propagate,
and XCTest (should) print out the description of the error message.