### PR TITLE
Surely 1 million is enough...

### DIFF
--- a/Sources/Benchmark/BenchmarkSetting.swift
+++ b/Sources/Benchmark/BenchmarkSetting.swift
@@ -74,6 +74,6 @@ struct BenchmarkSettings {
 }
 
 let defaultSettings: [BenchmarkSetting] = [
-    .maxIterations(1_000_000_000),
+    .maxIterations(1_000_000),
     .minTime(seconds: 1.0),
 ]


### PR DESCRIPTION
Reduce the default `.maxIterations` setting down from 1 Billion down to
1 Million.