### PR TITLE
Fix non-termination in adaptive iterations loop

### DIFF
--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -104,9 +104,9 @@ public struct BenchmarkRunner {
 
     /// Heuristic when to stop looking for new number of iterations, ported from google/benchmark.
     func hasCollectedEnoughData(_ measurements: [Double], settings: BenchmarkSettings) -> Bool {
-        let tooManyIterations = measurements.count > settings.maxIterations
+        let tooManyIterations = measurements.count >= settings.maxIterations
         let timeInSeconds = measurements.reduce(0, +) / 1000000000.0
-        let timeIsLargeEnough = timeInSeconds > settings.minTime
+        let timeIsLargeEnough = timeInSeconds >= settings.minTime
         return tooManyIterations || timeIsLargeEnough
     }
 
@@ -120,6 +120,7 @@ public struct BenchmarkRunner {
             measurements = doNIterations(n, benchmark: benchmark, suite: suite)
             if n != 1 && hasCollectedEnoughData(measurements, settings: settings) { break }
             n = predictNumberOfIterationsNeeded(measurements, settings: settings)
+            assert(n > measurements.count, "Number of iterations should increase with every retry.")
         }
 
         return measurements

--- a/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
@@ -32,10 +32,18 @@ final class BenchmarkRunnerTests: XCTestCase {
         XCTAssertEqual(Set(["suite1/b1"]), runBenchmarks(settings: settings))
     }
 
+    func testAutomaticallyDetectIterations() throws {
+        let settings: [BenchmarkSetting] = []
+        XCTAssertEqual(
+            Set(["suite2/b2", "suite2/b1", "suite1/b2", "suite1/b1"]),
+            runBenchmarks(settings: settings))
+    }
+
     static var allTests = [
         ("testFilterBenchmarksSuffix", testFilterBenchmarksSuffix),
         ("testFilterBenchmarksSuiteName", testFilterBenchmarksSuiteName),
         ("testFilterBenchmarksFullName", testFilterBenchmarksFullName),
+        ("testAutomaticallyDetectIterations", testAutomaticallyDetectIterations),
     ]
 }
 


### PR DESCRIPTION
In #19, we decreased the default number of max iterations. This change has uncovered a bug in the adaptive iterations discovery: if number of iterations is at maximum, but it still does not satisfy minimum time requirement it would endlessly keep retrying the same number of iterations over and over.

The change also adds an assert to make sure that we crash in cases like that in the future.