### PR TITLE
Add example output to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ add string no capacity        35380.0 ns  ± 5035.122635576142  38603
 add string reserved capacity  37466.0 ns  ± 4940.675061813501  36990
 ```
 
-For more examples, see Sources/BenchmarkMinimalExample and
-Sources/BenchmarkSuiteExample.
+For more examples, see
+[Sources/BenchmarkMinimalExample](./Sources/BenchmarkMinimalExample) and
+[Sources/BenchmarkSuiteExample](./Sources/BenchmarkSuiteExample).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ more details on what options are available, pass either the `-h` or `--help` com
 
 Example:
 
-```bash
+```terminal
 $ swift run -c release BenchmarkMinimalExample -h
 [3/3] Linking BenchmarkMinimalExample
 USAGE: benchmark-command [--allow-debug-build] [--filter <filter>] [--iterations <iterations>] [--warmup-iterations <warmup-iterations>] [--min-time <min-time>] [--max-iterations <max-iterations>]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ OPTIONS:
   --max-iterations <max-iterations>
                           Maximum number of iterations to run when automatically detecting number iterations.
   -h, --help              Show help information.
+
+$ swift run -c release BenchmarkMinimalExample
+running add string no capacity... done! (1795.09 ms)
+running add string reserved capacity... done! (1815.80 ms)
+
+name                          time        std                  iterations
+-------------------------------------------------------------------------
+add string no capacity        35380.0 ns  ± 5035.122635576142  38603
+add string reserved capacity  37466.0 ns  ± 4940.675061813501  36990
 ```
 
 For more examples, see Sources/BenchmarkMinimalExample and


### PR DESCRIPTION
As someone taking a first look at this project, I was curious to see what kind of information was included as part of the benchmark. And after reading #13, I was particularly interested to see what the plain text output format looked like.

Currently, the README shows the `USAGE` output from running a benchmark with the `-h` flag. This PR extends the example to show the output of running without that flag.

```terminal
$ swift run -c release BenchmarkMinimalExample
running add string no capacity... done! (1795.09 ms)
running add string reserved capacity... done! (1815.80 ms)

name                          time        std                  iterations
-------------------------------------------------------------------------
add string no capacity        35380.0 ns  ± 5035.122635576142  38603
add string reserved capacity  37466.0 ns  ± 4940.675061813501  36990
```

In addition, this PR also changes the code block language from `bash` to `terminal` (which prevents tokens like `time` and `help` from being highlighted out of context), and adds links to the example project in the source tree. If you'd rather consider these changes separately or reject them, please let me know and I can rebase my branch accordingly.