### PR TITLE
Add JSON formatted output

### DIFF
--- a/Sources/Benchmark/BenchmarkCommand.swift
+++ b/Sources/Benchmark/BenchmarkCommand.swift
@@ -36,6 +36,9 @@ internal struct BenchmarkCommand: ParsableCommand {
         help: "Maximum number of iterations to run when automatically detecting number iterations.")
     var maxIterations: Int?
 
+    @Option(help: "Number of warm-up iterations to run.")
+    var benchmarkFormat: BenchmarkFormat?
+
     var settings: [BenchmarkSetting] {
         var result: [BenchmarkSetting] = []
 
@@ -54,6 +57,10 @@ internal struct BenchmarkCommand: ParsableCommand {
         if let value = maxIterations {
             result.append(.maxIterations(value))
         }
+        if let value = benchmarkFormat {
+            result.append(.benchmarkFormat(value))
+        }
+
 
         return result
     }

--- a/Sources/Benchmark/BenchmarkFormat.swift
+++ b/Sources/Benchmark/BenchmarkFormat.swift
@@ -1,0 +1,6 @@
+import ArgumentParser
+
+public enum BenchmarkFormat: String, ExpressibleByArgument {
+    case console
+    case json
+}

--- a/Sources/Benchmark/BenchmarkMain.swift
+++ b/Sources/Benchmark/BenchmarkMain.swift
@@ -15,12 +15,10 @@
 public func main(_ suites: [BenchmarkSuite]) {
     let command = BenchmarkCommand.parseOrExit()
     let settings = command.settings
-    let reporter = PlainTextReporter()
 
     var runner = BenchmarkRunner(
         suites: suites,
-        settings: settings,
-        reporter: reporter)
+        settings: settings)
     try! runner.run()
 }
 

--- a/Sources/Benchmark/BenchmarkReport.swift
+++ b/Sources/Benchmark/BenchmarkReport.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct BenchmarkReport: Encodable {
+    struct Context: Encodable {
+        let date: Date = Date()
+    }
+
+    let context: Context
+    let results: [BenchmarkResult]
+
+    init(results: [BenchmarkResult]) {
+        self.context = Context()
+        self.results = results
+    }
+}

--- a/Sources/Benchmark/BenchmarkReporter.swift
+++ b/Sources/Benchmark/BenchmarkReporter.swift
@@ -79,3 +79,28 @@ struct PlainTextReporter: BenchmarkReporter {
         }
     }
 }
+
+struct JSONReporter: BenchmarkReporter {
+    func report(running name: String, suite: String) {}
+
+    func report(finishedRunning name: String, suite: String, nanosTaken: UInt64) {}
+
+    func report(results: [BenchmarkResult]) {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+
+        if #available(macOS 10.12, *) {
+            encoder.dateEncodingStrategy = .iso8601
+        }
+
+        do {
+            let report = BenchmarkReport(results: results)
+            let data = try encoder.encode(report)
+            if let json = String(data: data, encoding: .utf8) {
+                print(json)
+            }
+        } catch {
+            fatalError("\(error)")
+        }
+    }
+}

--- a/Sources/Benchmark/BenchmarkResult.swift
+++ b/Sources/Benchmark/BenchmarkResult.swift
@@ -23,3 +23,18 @@ public struct BenchmarkResult {
         self.measurements = measurements
     }
 }
+
+extension BenchmarkResult: Encodable {
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case iterations
+        case realTime = "real_time"
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode("\(suiteName)/\(benchmarkName)", forKey: .name)
+        try container.encode(measurements.count, forKey: .iterations)
+        try container.encode(sum(measurements), forKey: .realTime)
+    }
+}

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -18,10 +18,22 @@ public struct BenchmarkRunner {
     var reporter: BenchmarkReporter
     var results: [BenchmarkResult] = []
 
-    init(suites: [BenchmarkSuite], settings: [BenchmarkSetting], reporter: BenchmarkReporter) {
+    init(suites: [BenchmarkSuite], settings: [BenchmarkSetting]) {
         self.suites = suites
         self.settings = settings
-        self.reporter = reporter
+
+        var format: BenchmarkFormat = .console
+        for case .benchmarkFormat(let value) in settings {
+            format = value
+            break
+        }
+
+        switch format {
+        case .console:
+            self.reporter = PlainTextReporter()
+        case .json:
+            self.reporter = JSONReporter()
+        }
     }
 
     mutating func run() throws {

--- a/Sources/Benchmark/BenchmarkSetting.swift
+++ b/Sources/Benchmark/BenchmarkSetting.swift
@@ -18,6 +18,7 @@ public enum BenchmarkSetting {
     case warmupIterations(Int)
     case filter(String)
     case minTime(seconds: Double)
+    case benchmarkFormat(BenchmarkFormat)
 }
 
 struct BenchmarkSettings {
@@ -26,6 +27,7 @@ struct BenchmarkSettings {
     let maxIterations: Int
     let filter: BenchmarkFilter
     let minTime: Double
+    let benchmarkFormat: BenchmarkFormat
 
     init(_ settings: [[BenchmarkSetting]]) throws {
         try self.init(Array(settings.joined()))
@@ -37,6 +39,7 @@ struct BenchmarkSettings {
         var maxIterations: Int = -1
         var filter: String? = nil
         var minTime: Double = -1
+        var benchmarkFormat: BenchmarkFormat = .console
 
         for setting in settings {
             switch setting {
@@ -50,6 +53,8 @@ struct BenchmarkSettings {
                 maxIterations = value
             case .minTime(let value):
                 minTime = value
+            case .benchmarkFormat(let value):
+                benchmarkFormat = value
             }
         }
 
@@ -58,18 +63,20 @@ struct BenchmarkSettings {
             warmupIterations: warmupIterations,
             maxIterations: maxIterations,
             filter: filter,
-            minTime: minTime)
+            minTime: minTime,
+            benchmarkFormat: benchmarkFormat)
     }
 
     init(
         iterations: Int?, warmupIterations: Int?, maxIterations: Int, filter: String?,
-        minTime: Double
+        minTime: Double, benchmarkFormat: BenchmarkFormat
     ) throws {
         self.iterations = iterations
         self.warmupIterations = warmupIterations
         self.maxIterations = maxIterations
         self.filter = try BenchmarkFilter(filter)
         self.minTime = minTime
+        self.benchmarkFormat = benchmarkFormat
     }
 }
 


### PR DESCRIPTION
Resolves #13 

Still need to add tests, documentation, and do a refactoring pass, but I wanted to share my progress so far to get some early feedback.

```terminal
$ swift run -c release BenchmarkMinimalExample --benchmark-format json
```

```json
{
  "context" : {
    "date" : "2020-05-14T18:19:03Z"
  },
  "results" : [
    {
      "name" : "\/add string no capacity",
      "iterations" : 40926,
      "real_time" : 1404114353
    },
    {
      "name" : "\/add string reserved capacity",
      "iterations" : 42257,
      "real_time" : 1402417122
    }
  ]
}
```

<ins>Edit</ins>: Tests are currently failing because I changed the initialization pattern for `BenchMarkRunner`. Curious to know if the use of `BlackHoleReporter` is important, or if `PlainTextReporter` would work just as well for testing.