### PR TITLE
Round off the standard deviation.

### DIFF
--- a/Sources/Benchmark/BenchmarkReporter.swift
+++ b/Sources/Benchmark/BenchmarkReporter.swift
@@ -52,8 +52,11 @@ struct PlainTextReporter: BenchmarkReporter {
                 name = result.benchmarkName
             }
             nameColumn.append(name)
-            timeColumn.append("\(median(result.measurements)) ns")
-            stdColumn.append("± \(String(format: "%.2f", std(result.measurements)))")
+            let median = result.measurements.median
+            let stddev = result.measurements.std
+            let stddevRatio = (stddev / median) * 100
+            timeColumn.append("\(median) ns")
+            stdColumn.append("± \(String(format: "%6.2f %%", stddevRatio))")
             iterationsColumn.append(String(result.measurements.count))
         }
 

--- a/Sources/Benchmark/BenchmarkReporter.swift
+++ b/Sources/Benchmark/BenchmarkReporter.swift
@@ -53,7 +53,7 @@ struct PlainTextReporter: BenchmarkReporter {
             }
             nameColumn.append(name)
             timeColumn.append("\(median(result.measurements)) ns")
-            stdColumn.append("± \(std(result.measurements))")
+            stdColumn.append("± \(String(format: "%.2f", std(result.measurements)))")
             iterationsColumn.append(String(result.measurements.count))
         }
 

--- a/Sources/Benchmark/Stats.swift
+++ b/Sources/Benchmark/Stats.swift
@@ -14,55 +14,60 @@
 
 // Statistics utility functions, ported from google/benchmark.
 
-func sum(_ v: [Double]) -> Double {
-    var total: Double = 0
-    for x in v {
-        total += x
-    }
-    return total
-}
+// TODO: consider making these generic over more Collection and Element types.
+// For now, however, they are intentionally limited in scope.
+extension Array where Element == Double {
 
-func sumSquared(_ v: [Double]) -> Double {
-    var total: Double = 0
-    for x in v {
-        total += x * x
-    }
-    return total
-}
-
-func mean(_ v: [Double]) -> Double {
-    if v.count == 0 {
-        return 0
-    } else {
-        let invCount: Double = 1.0 / Double(v.count)
-        return sum(v) * invCount
-    }
-}
-
-func median(_ v: [Double]) -> Double {
-    guard v.count >= 2 else { return mean(v) }
-
-    // If we have odd number of elements, then
-    // center element is the median.
-    let sorted = v.sorted()
-    let center = v.count / 2
-    if v.count % 2 == 1 {
-        return sorted[center]
+    var sum: Double {
+        var total: Double = 0
+        for x in self {
+            total += x
+        }
+        return total
     }
 
-    // If have even number of elements we need
-    // to return an average between two middle elements.
-    let center2 = v.count / 2 - 1
-    return (sorted[center] + sorted[center2]) / 2
-}
+    var sumSquared: Double {
+        var total: Double = 0
+        for x in self {
+            total += x * x
+        }
+        return total
+    }
 
-func std(_ v: [Double]) -> Double {
-    let count = Double(v.count)
-    // Standard deviation is undefined for n = 0 or 1.
-    guard count > 0 else { return 0 }
-    guard count > 1 else { return 0 }
+    var mean: Double {
+        if count == 0 {
+            return 0
+        } else {
+            let invCount: Double = 1.0 / Double(count)
+            return sum * invCount
+        }
+    }
 
-    let meanValue = mean(v)
-    let avgSquares = sumSquared(v) * (1.0 / count)
-    return (count / (count - 1) * (avgSquares - meanValue * meanValue)).squareRoot()
+    var median: Double {
+        guard count >= 2 else { return mean }
+
+        // If we have odd number of elements, then
+        // center element is the median.
+        let s = self.sorted()
+        let center = count / 2
+        if count % 2 == 1 {
+            return s[center]
+        }
+
+        // If have even number of elements we need
+        // to return an average between two middle elements.
+        let center2 = count / 2 - 1
+        return (s[center] + s[center2]) / 2
+    }
+
+    var std: Double {
+        let c = Double(count)
+        // Standard deviation is undefined for n = 0 or 1.
+        guard c > 0 else { return 0 }
+        guard c > 1 else { return 0 }
+
+        let meanValue = mean
+        let avgSquares = sumSquared * (1.0 / c)
+        return (c / (c - 1) * (avgSquares - meanValue * meanValue)).squareRoot()
+    }
 }

--- a/Tests/BenchmarkTests/StatsTests.swift
+++ b/Tests/BenchmarkTests/StatsTests.swift
@@ -26,62 +26,62 @@ final class StatsTests: XCTestCase {
     let v6: [Double] = [21, 42, 84]
 
     func testSum() {
-        XCTAssertEqual(sum(v0), 0)
-        XCTAssertEqual(sum(v1), 1)
-        XCTAssertEqual(sum(v2), 10)
-        XCTAssertEqual(sum(v4), 42)
-        XCTAssertEqual(sum(v5), 63)
+        XCTAssertEqual(v0.sum, 0)
+        XCTAssertEqual(v1.sum, 1)
+        XCTAssertEqual(v2.sum, 10)
+        XCTAssertEqual(v4.sum, 42)
+        XCTAssertEqual(v5.sum, 63)
     }
 
     func testSumSquared() {
         let squared0: [Double] = []
-        XCTAssertEqual(sumSquared(v0), sum(squared0))
+        XCTAssertEqual(v0.sumSquared, squared0.sum)
         let squared1: [Double] = [0.1 * 0.1, 0.2 * 0.2, 0.3 * 0.3, 0.4 * 0.4]
-        XCTAssertEqual(sumSquared(v1), sum(squared1))
+        XCTAssertEqual(v1.sumSquared, squared1.sum)
         let squared2: [Double] = [1, 4, 9, 16]
-        XCTAssertEqual(sumSquared(v2), sum(squared2))
+        XCTAssertEqual(v2.sumSquared, squared2.sum)
         let squared3: [Double] = [1, 4, 9, 16, 25]
-        XCTAssertEqual(sumSquared(v3), sum(squared3))
+        XCTAssertEqual(v3.sumSquared, squared3.sum)
         let squared4: [Double] = [1764]
-        XCTAssertEqual(sumSquared(v4), sum(squared4))
+        XCTAssertEqual(v4.sumSquared, squared4.sum)
         let squared5: [Double] = [441, 1764]
-        XCTAssertEqual(sumSquared(v5), sum(squared5))
+        XCTAssertEqual(v5.sumSquared, squared5.sum)
     }
 
     func testMean() {
-        XCTAssertEqual(mean(v0), 0)
-        XCTAssertEqual(mean(v1), 0.25)
-        XCTAssertEqual(mean(v2), 2.5)
-        XCTAssertEqual(mean(v3), 3)
-        XCTAssertEqual(mean(v4), 42)
-        XCTAssertEqual(mean(v5), 31.5)
+        XCTAssertEqual(v0.mean, 0)
+        XCTAssertEqual(v1.mean, 0.25)
+        XCTAssertEqual(v2.mean, 2.5)
+        XCTAssertEqual(v3.mean, 3)
+        XCTAssertEqual(v4.mean, 42)
+        XCTAssertEqual(v5.mean, 31.5)
     }
 
     func testMedian() {
-        XCTAssertEqual(median(v0), 0)
-        XCTAssertEqual(median(v1), 0.25)
-        XCTAssertEqual(median(v2), 2.5)
-        XCTAssertEqual(median(v3), 3)
-        XCTAssertEqual(median(v4), 42)
-        XCTAssertEqual(median(v5), 31.5)
-        XCTAssertEqual(median(v6), 42)
+        XCTAssertEqual(v0.median, 0)
+        XCTAssertEqual(v1.median, 0.25)
+        XCTAssertEqual(v2.median, 2.5)
+        XCTAssertEqual(v3.median, 3)
+        XCTAssertEqual(v4.median, 42)
+        XCTAssertEqual(v5.median, 31.5)
+        XCTAssertEqual(v6.median, 42)
     }
 
     func testStd() {
         let std0: Double = 0.0
-        XCTAssertEqual(std(v0), std0)
+        XCTAssertEqual(v0.std, std0)
         let std1: Double = 0.1290994448735806
-        XCTAssertEqual(std(v1), std1)
+        XCTAssertEqual(v1.std, std1)
         let std2: Double = 1.2909944487358056
-        XCTAssertEqual(std(v2), std2)
+        XCTAssertEqual(v2.std, std2)
         let std3: Double = 1.5811388300841898
-        XCTAssertEqual(std(v3), std3)
+        XCTAssertEqual(v3.std, std3)
         let std4: Double = 0
-        XCTAssertEqual(std(v4), std4)
+        XCTAssertEqual(v4.std, std4)
         let std5: Double = 14.849242404917497
-        XCTAssertEqual(std(v5), std5)
+        XCTAssertEqual(v5.std, std5)
         let std6: Double = 32.07802986469088
-        XCTAssertEqual(std(v6), std6)
+        XCTAssertEqual(v6.std, std6)
     }
 
     static var allTests = [


### PR DESCRIPTION
Previously, it would print out a huge number of values past the decimal
point. This seems silly to me. This change it to just 2 as a starting point.
(I think ideally in the long term, we should calculate the appropriate
number of significant figures to not be mis-leading. But we can start here.)

Before:

```
name                                                                   time            std                   iterations
-----------------------------------------------------------------------------------------------------------------------
NonBlockingCondition: notify one, no waiters                           49.0 ns         ± 218.03171899854937  1000000
NonBlockingCondition: notify all, no waiters                           48.0 ns         ± 259.1237923013594   1000000
NonBlockingCondition: preWait, cancelWait                              62.0 ns         ± 318.1394131555278   1000000
```

After:

```
name                                                                   time            std           iterations
---------------------------------------------------------------------------------------------------------------
NonBlockingCondition: notify one, no waiters                           55.0 ns         ± 141.28      1000000
NonBlockingCondition: notify all, no waiters                           48.0 ns         ± 285.49      1000000
NonBlockingCondition: preWait, cancelWait                              63.0 ns         ± 262.61      1000000

```