### PR TITLE
Right-justify time output in the console

### DIFF
--- a/Sources/Benchmark/BenchmarkReporter.swift
+++ b/Sources/Benchmark/BenchmarkReporter.swift
@@ -18,7 +18,7 @@ extension String {
     func leftPadding(toLength: Int, withPad: String) -> String {
         let stringLength = self.count
         if stringLength < toLength {
-            return String(repeating:withPad, count: toLength - stringLength) + self
+            return String(repeating: withPad, count: toLength - stringLength) + self
         } else {
             return String(self.suffix(toLength))
         }

--- a/Sources/Benchmark/BenchmarkReporter.swift
+++ b/Sources/Benchmark/BenchmarkReporter.swift
@@ -17,12 +17,28 @@ import Foundation
 extension String {
     func leftPadding(toLength: Int, withPad: String) -> String {
         let stringLength = self.count
-        if stringLength < toLength {
+        if stringLength <= toLength {
             return String(repeating: withPad, count: toLength - stringLength) + self
         } else {
-            return String(self.suffix(toLength))
+            #if DEBUG
+            //When call fatalError(), stop all program (that include debug).
+            //So return String in debug.
+            return "Triggar fatalError"
+            #endif
+            fatalError("'toLength' must be greater than or equal to 'stringLength'.\n")
         }
     }
+}
+
+func paddingEachCell(cell: String, index: Int, columnIndex: Int, length: Int) -> String {
+    var paddedCell = ""
+    if index != 0 && columnIndex == 1 {
+        paddedCell = cell.leftPadding(toLength: length, withPad:" ")
+    } else {
+        paddedCell = cell.padding(
+            toLength: length, withPad: " ", startingAt: 0)
+    }
+    return paddedCell
 }
 
 protocol BenchmarkReporter {
@@ -79,15 +95,9 @@ struct PlainTextReporter: BenchmarkReporter {
         print("")
         for index in 0...results.count {
             for columnIndex in 0..<columns.count {
-                let cell = columns[columnIndex][index]
-                var padded = ""
-                if (index != 0 && columnIndex == 1) {
-                    padded = cell.leftPadding(toLength: widths[columnIndex], withPad:" ")
-                } else {
-                    padded = cell.padding(
-                    toLength: widths[columnIndex], withPad: " ", startingAt: 0)
-                }
-                print(padded, terminator: "  ")
+                let paddedCell = paddingEachCell(cell: columns[columnIndex][index],
+                    index: index, columnIndex: columnIndex, length: widths[columnIndex])
+                print(paddedCell, terminator: "  ")
             }
             print("")
             if index == 0 {

--- a/Sources/Benchmark/BenchmarkReporter.swift
+++ b/Sources/Benchmark/BenchmarkReporter.swift
@@ -14,6 +14,17 @@
 
 import Foundation
 
+extension String {
+    func leftPadding(toLength: Int, withPad: String) -> String {
+        let stringLength = self.count
+        if stringLength < toLength {
+            return String(repeating:withPad, count: toLength - stringLength) + self
+        } else {
+            return String(self.suffix(toLength))
+        }
+    }
+}
+
 protocol BenchmarkReporter {
     mutating func report(running name: String, suite: String)
     mutating func report(finishedRunning name: String, suite: String, nanosTaken: UInt64)
@@ -69,8 +80,13 @@ struct PlainTextReporter: BenchmarkReporter {
         for index in 0...results.count {
             for columnIndex in 0..<columns.count {
                 let cell = columns[columnIndex][index]
-                let padded = cell.padding(
+                var padded = ""
+                if (index != 0 && columnIndex == 1) {
+                    padded = cell.leftPadding(toLength: widths[columnIndex], withPad:" ")
+                } else {
+                    padded = cell.padding(
                     toLength: widths[columnIndex], withPad: " ", startingAt: 0)
+                }
                 print(padded, terminator: "  ")
             }
             print("")

--- a/Tests/BenchmarkTests/BenchmarkReporterTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkReporterTests.swift
@@ -1,0 +1,53 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import Benchmark
+
+final class BenchmarkReporterTests: XCTestCase {
+
+    func testPaddingLeft() throws {
+        let testText = "testText"
+        XCTAssertEqual(testText.leftPadding(toLength: testText.count, withPad:" "), "testText")
+        XCTAssertEqual(testText.leftPadding(toLength: testText.count + 3, withPad:" "), "   testText")
+        XCTAssertEqual(testText.leftPadding(toLength: testText.count - 1, withPad:" "), "Triggar fatalError")
+    }
+
+    func testPaddingEachCell() throws {
+        let dummyName = ["00", "10", "20"]
+        let dummyTime = ["01", "11", "21"]
+        let dummyStd = ["02", "12", "22"]
+        let dummyIterations = ["03", "13", "23"]
+        let columuns = [dummyName, dummyTime, dummyStd, dummyIterations]
+
+        for index in 0..<dummyName.count {
+            for columnIndex in 0..<columuns.count {
+                let cell = columuns[columnIndex][index]
+                let paddedCell = paddingEachCell(cell: cell,
+                    index: index, columnIndex: columnIndex, length: cell.count + 1)
+                if index != 0 && columnIndex == 1 {
+                    XCTAssertEqual(paddedCell, " \(index)\(columnIndex)")
+                } else {
+                    XCTAssertEqual(paddedCell, "\(index)\(columnIndex) ")
+                }
+            }
+        }
+    }
+
+    static var allTests = [
+        ("testPaddingLeft", testPaddingLeft),
+        ("testPaddingEachCell", testPaddingEachCell)
+    ]
+}

--- a/Tests/BenchmarkTests/XCTTestManifests.swift
+++ b/Tests/BenchmarkTests/XCTTestManifests.swift
@@ -21,6 +21,7 @@ import XCTest
             testCase(BenchmarkRunnerTests.allTests),
             testCase(BenchmarkSettingTests.allTests),
             testCase(StatsTests.allTests),
+            testCase(BenchmarkReporterTests.allTests),
         ]
     }
 #endif


### PR DESCRIPTION
Fixes #25 

before
```
name                          time             std         iterations
---------------------------------------------------------------------
add string no capacity        40215.0 ns       ±  24.40 %  32485
add string reserved capacity  4316510990.0 ns  ±   0.58 %  2
```

after
```
name                          time            std         iterations
--------------------------------------------------------------------
add string no capacity            40214.0 ns  ±  23.67 %  32319
add string reserved capacity  432951866.0 ns  ±   2.09 %  3
```