### PR TITLE
Added in support for custom columns

### DIFF
--- a/Sources/Benchmark/BenchmarkCommand.swift
+++ b/Sources/Benchmark/BenchmarkCommand.swift
@@ -15,6 +15,12 @@
 import ArgumentParser
 import Foundation
 
+public enum Column: String, ExpressibleByArgument {
+    case time
+    case std
+    case iterations
+}
+
 /// Allows dynamic configuration of the benchmark execution.
 internal struct BenchmarkCommand: ParsableCommand {
     @Flag(help: "Overrides check to verify optimized build.")
@@ -36,6 +42,9 @@ internal struct BenchmarkCommand: ParsableCommand {
         help: "Maximum number of iterations to run when automatically detecting number iterations.")
     var maxIterations: Int?
 
+    @Option(parsing: .upToNextOption, help: "Desired columns to be included in the output")
+    private var columns: [Column]
+
     var settings: [BenchmarkSetting] {
         var result: [BenchmarkSetting] = []
 
@@ -55,6 +64,12 @@ internal struct BenchmarkCommand: ParsableCommand {
             result.append(.maxIterations(value))
         }
 
+        return result
+    }
+    
+    var selectedColumns: [Column] {
+        let result = columns.count > 0 ? columns : [ .time, .std, .iterations]
+        
         return result
     }
 

--- a/Sources/Benchmark/BenchmarkCommand.swift
+++ b/Sources/Benchmark/BenchmarkCommand.swift
@@ -15,7 +15,7 @@
 import ArgumentParser
 import Foundation
 
-public enum Column: String, ExpressibleByArgument {
+public enum Column: String, ExpressibleByArgument, Decodable {
     case time
     case std
     case iterations
@@ -42,7 +42,7 @@ internal struct BenchmarkCommand: ParsableCommand {
         help: "Maximum number of iterations to run when automatically detecting number iterations.")
     var maxIterations: Int?
 
-    @Option(parsing: .upToNextOption, help: "Desired columns to be included in the output")
+    @Option(name: .customLong("show"), parsing: .upToNextOption, help: "Desired columns to be included in the output")
     private var columns: [Column]
 
     var settings: [BenchmarkSetting] {

--- a/Sources/Benchmark/BenchmarkMain.swift
+++ b/Sources/Benchmark/BenchmarkMain.swift
@@ -15,7 +15,7 @@
 public func main(_ suites: [BenchmarkSuite]) {
     let command = BenchmarkCommand.parseOrExit()
     let settings = command.settings
-    let reporter = PlainTextReporter()
+    let reporter = PlainTextReporter(columns: command.selectedColumns)
 
     var runner = BenchmarkRunner(
         suites: suites,

--- a/Sources/Benchmark/BenchmarkReporter.swift
+++ b/Sources/Benchmark/BenchmarkReporter.swift
@@ -18,9 +18,14 @@ protocol BenchmarkReporter {
     mutating func report(running name: String, suite: String)
     mutating func report(finishedRunning name: String, suite: String, nanosTaken: UInt64)
     mutating func report(results: [BenchmarkResult])
+    
+    var columns: [Column] { get set }
 }
 
 struct PlainTextReporter: BenchmarkReporter {
+    
+    var columns: [Column]
+    
     func report(running name: String, suite: String) {
         let prefix: String
         if suite != "" {
@@ -60,7 +65,24 @@ struct PlainTextReporter: BenchmarkReporter {
             iterationsColumn.append(String(result.measurements.count))
         }
 
-        let columns = [nameColumn, timeColumn, stdColumn, iterationsColumn]
+        // I dislike this but I can't think of a cleaner way
+        // that doesn't rely on the string rawValue of the enum
+        // and the first row of the columns matching up with this
+        var columns = [nameColumn]
+        for outFilter in self.columns {
+            switch outFilter
+            {
+            case .std:
+                columns.append(stdColumn)
+
+            case .time:
+                columns.append(timeColumn)
+
+            case .iterations:
+                columns.append(iterationsColumn)
+            }
+        }
+
         for column in columns {
             widths.append(column.map { $0.count }.max()!)
         }

--- a/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
@@ -64,7 +64,7 @@ extension BenchmarkRunnerTests {
         var runner = BenchmarkRunner(
             suites: [suite1, suite2],
             settings: settings,
-            reporter: BlackHoleReporter())
+            reporter: BlackHoleReporter(columns: [ .time, .std, .iterations]))
 
         do {
             try runner.run()

--- a/Tests/BenchmarkTests/BenchmarkSettingTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkSettingTests.swift
@@ -23,7 +23,7 @@ final class BenchmarkSettingTests: XCTestCase {
         counts expected: [Int],
         cli settings: [BenchmarkSetting] = [.iterations(100000)]
     ) throws {
-        var runner = BenchmarkRunner(suites: [suite], settings: settings, reporter: BlackHoleReporter())
+        var runner = BenchmarkRunner(suites: [suite], settings: settings, reporter: BlackHoleReporter(columns: [ .time, .std, .iterations]))
 
         try runner.run()
         XCTAssertEqual(runner.results.count, expected.count)

--- a/Tests/BenchmarkTests/BlackHoleReporter.swift
+++ b/Tests/BenchmarkTests/BlackHoleReporter.swift
@@ -15,6 +15,8 @@
 @testable import Benchmark
 
 struct BlackHoleReporter: BenchmarkReporter {
+    var columns: [Column]
+    
     func report(running name: String, suite: String) {}
     func report(finishedRunning name: String, suite: String, nanosTaken: UInt64) {}
     func report(results: [BenchmarkResult]) {}


### PR DESCRIPTION
This is a preliminary attempt at adding in user selectable columns to resolve #15.

Currently only the name column is assumed and also the leading column.
This does mean you could say request the standard deviation and nothing else which makes little sense.
Unsure as to exactly what combinations of columns should be allowed, or if allowing anything is ok.