### PR TITLE
Add optional setUp and tearDown requirements to AnyBenchmark

### DIFF
--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -15,7 +15,14 @@
 public protocol AnyBenchmark {
     var name: String { get }
     var settings: [BenchmarkSetting] { get }
+    func setUp()
     func run()
+    func tearDown()
+}
+
+extension AnyBenchmark {
+    func setUp() {}
+    func tearDown() {}
 }
 
 internal class ClosureBenchmark: AnyBenchmark {

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -137,9 +137,11 @@ public struct BenchmarkRunner {
         measurements.reserveCapacity(n)
 
         for _ in 1...n {
+            benchmark.setUp()
             clock.recordStart()
             benchmark.run()
             clock.recordEnd()
+            benchmark.tearDown()
             measurements.append(Double(clock.elapsed))
         }
 

--- a/Tests/BenchmarkTests/CustomBenchmarkTests.swift
+++ b/Tests/BenchmarkTests/CustomBenchmarkTests.swift
@@ -1,0 +1,61 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import Benchmark
+
+final class CustomBenchmarkTests: XCTestCase {
+    func testSetUpAndTearDown() throws {
+        let benchmark = MockBenchmark()
+
+        let suite = BenchmarkSuite(name: "suite")
+        suite.benchmarks = [benchmark]
+
+        var runner = BenchmarkRunner(suites: [suite], settings: [], reporter: BlackHoleReporter())
+
+        try runner.run()
+
+        XCTAssertTrue(benchmark.didSetUp)
+        XCTAssertTrue(benchmark.didRun)
+        XCTAssertTrue(benchmark.didTearDown)
+    }
+
+    static var allTests = [
+        ("testSetUpAndTearDown", testSetUpAndTearDown),
+    ]
+}
+
+fileprivate class MockBenchmark: AnyBenchmark {
+    let name = "Custom"
+
+    var settings: [BenchmarkSetting] = []
+
+    var didSetUp: Bool = false
+    var didRun: Bool = false
+    var didTearDown: Bool = false
+
+    func setUp() {
+        didSetUp = true
+    }
+
+    func run() {
+        didRun = true
+    }
+
+    func tearDown() {
+        didTearDown = true
+    }
+}
+

--- a/Tests/BenchmarkTests/XCTTestManifests.swift
+++ b/Tests/BenchmarkTests/XCTTestManifests.swift
@@ -20,6 +20,7 @@ import XCTest
             testCase(BenchmarkCommandTests.allTests),
             testCase(BenchmarkRunnerTests.allTests),
             testCase(BenchmarkSettingTests.allTests),
+            testCase(CustomBenchmarkTests.allTests),
             testCase(StatsTests.allTests),
         ]
     }


### PR DESCRIPTION
This is an alternative solution to what was discussed in #29. Rather than introducing a new pattern for defining setup and teardown behavior, this PR implements this functionality using the same, familiar pattern seen in [`XCTest`](https://developer.apple.com/documentation/xctest/xctestcase).

By providing a default implementation of `setUp()` and `tearDown()` in an unconstrained extension on the `AnyBenchmark` protocol, we make them effectively optional requirements. This change has no impact on existing code. 