### PR TITLE
Refactor PlainTextReporter

### DIFF
--- a/Sources/Benchmark/BenchmarkReporter.swift
+++ b/Sources/Benchmark/BenchmarkReporter.swift
@@ -91,9 +91,9 @@ struct PlainTextReporter<Target>: BenchmarkReporter where Target : TextOutputStr
                 let string = row[column]!
                 let width = widths[column]!
                 switch column {
-                case .name, .standardDeviation, .iterations:
+                case .name, .standardDeviation:
                     return string.padding(toLength: width, withPad: " ", startingAt: 0)
-                case .time:
+                case .time, .iterations:
                     return string.leftPadding(toLength: width, withPad:" ")
                 }
             }

--- a/Sources/Benchmark/BenchmarkReporter.swift
+++ b/Sources/Benchmark/BenchmarkReporter.swift
@@ -15,18 +15,9 @@
 import Foundation
 
 extension String {
-    func leftPadding(toLength: Int, withPad: String) -> String {
-        let stringLength = self.count
-        if stringLength <= toLength {
-            return String(repeating: withPad, count: toLength - stringLength) + self
-        } else {
-            #if DEBUG
-            //When call fatalError(), stop all program (that include debug).
-            //So return String in debug.
-            return "Triggar fatalError"
-            #endif
-            fatalError("'toLength' must be greater than or equal to 'stringLength'.\n")
-        }
+    func leftPadding(toLength newLength: Int, withPad character: Character) -> String {
+        precondition(count <= newLength, "newLength must be greater than or equal to string length")
+        return String(repeating: character, count: newLength - count) + self
     }
 }
 

--- a/Sources/Benchmark/BenchmarkReporter.swift
+++ b/Sources/Benchmark/BenchmarkReporter.swift
@@ -99,11 +99,13 @@ struct PlainTextReporter<Target>: BenchmarkReporter where Target : TextOutputStr
                 }
             }
 
-            let line = components.joined(separator: " ")
+            let line = components.joined(separator: "\t")
             print(line, to: &output)
 
             if index == 0 {
-                print(String(repeating: "-", count: line.count), to: &output)
+                let separator = components.map { String(repeating: "-", count: $0.count) }
+                                          .joined(separator: "\t")
+                print(separator, to: &output)
             }
         }
     }

--- a/Sources/Benchmark/BenchmarkReporter.swift
+++ b/Sources/Benchmark/BenchmarkReporter.swift
@@ -99,13 +99,11 @@ struct PlainTextReporter<Target>: BenchmarkReporter where Target : TextOutputStr
                 }
             }
 
-            let line = components.joined(separator: "\t")
+            let line = components.joined(separator: " ")
             print(line, to: &output)
 
             if index == 0 {
-                let separator = components.map { String(repeating: "-", count: $0.count) }
-                                          .joined(separator: "\t")
-                print(separator, to: &output)
+                print(String(repeating: "-", count: line.count), to: &output)
             }
         }
     }

--- a/Sources/Benchmark/BenchmarkReporter.swift
+++ b/Sources/Benchmark/BenchmarkReporter.swift
@@ -111,7 +111,7 @@ struct PlainTextReporter<Target>: BenchmarkReporter where Target : TextOutputStr
 
 struct StdoutOutputStream: TextOutputStream {
     mutating func write(_ string: String) {
-        print(string)
+        fputs(string, stdout)
     }
 }
 

--- a/Sources/Benchmark/BenchmarkReporter.swift
+++ b/Sources/Benchmark/BenchmarkReporter.swift
@@ -91,8 +91,9 @@ struct PlainTextReporter<Target>: BenchmarkReporter where Target : TextOutputStr
                 let string = row[column]!
                 let width = widths[column]!
                 switch column {
-                case .name, .standardDeviation:
-                    return string.padding(toLength: width, withPad: " ", startingAt: 0)
+                case _ where index == 0,
+                     .name, .standardDeviation:
+                    return string.rightPadding(toLength: width, withPad:" ")
                 case .time, .iterations:
                     return string.leftPadding(toLength: width, withPad:" ")
                 }
@@ -118,5 +119,10 @@ fileprivate extension String {
     func leftPadding(toLength newLength: Int, withPad character: Character) -> String {
         precondition(count <= newLength, "newLength must be greater than or equal to string length")
         return String(repeating: character, count: newLength - count) + self
+    }
+
+    func rightPadding(toLength newLength: Int, withPad character: Character) -> String {
+        precondition(count <= newLength, "newLength must be greater than or equal to string length")
+        return self + String(repeating: character, count: newLength - count)
     }
 }

--- a/Tests/BenchmarkTests/BenchmarkReporterTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkReporterTests.swift
@@ -30,19 +30,17 @@ final class BenchmarkReporterTests: XCTestCase {
         reporter.report(results: results)
 
         let expected = #"""
-        name                   time std        iterations
+        name           time         std        iterations
         -------------------------------------------------
         My Suite: fast    1500.0 ns ±  47.14 %          2
         My Suite: slow 1500000.0 ns ±  47.14 %          2
         """#.split(separator: "\n").map { String($0) }
-
 
         let actual = output.lines.map {$0.trimmingCharacters(in: .whitespacesAndNewlines) }
                                  .filter { !$0.isEmpty}
         for (expectedLine, actualLine) in zip(expected, actual) {
             XCTAssertEqual(expectedLine, actualLine)
         }
-
     }
 
     static var allTests = [

--- a/Tests/BenchmarkTests/BenchmarkReporterTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkReporterTests.swift
@@ -22,7 +22,6 @@ final class BenchmarkReporterTests: XCTestCase {
         let testText = "testText"
         XCTAssertEqual(testText.leftPadding(toLength: testText.count, withPad:" "), "testText")
         XCTAssertEqual(testText.leftPadding(toLength: testText.count + 3, withPad:" "), "   testText")
-        XCTAssertEqual(testText.leftPadding(toLength: testText.count - 1, withPad:" "), "Triggar fatalError")
     }
 
     func testPaddingEachCell() throws {

--- a/Tests/BenchmarkTests/BenchmarkReporterTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkReporterTests.swift
@@ -29,12 +29,12 @@ final class BenchmarkReporterTests: XCTestCase {
 
         reporter.report(results: results)
 
-        let expected = """
-        name          \ttime        \tstd       \titerations
-        --------------\t------------\t----------\t----------
-        My Suite: fast\t   1500.0 ns\t±  47.14 %\t         2
-        My Suite: slow\t1500000.0 ns\t±  47.14 %\t         2
-        """.split(separator: "\n").map { String($0) }
+        let expected = #"""
+        name           time         std        iterations
+        -------------------------------------------------
+        My Suite: fast    1500.0 ns ±  47.14 %          2
+        My Suite: slow 1500000.0 ns ±  47.14 %          2
+        """#.split(separator: "\n").map { String($0) }
 
         let actual = output.lines.map {$0.trimmingCharacters(in: .whitespacesAndNewlines) }
                                  .filter { !$0.isEmpty}

--- a/Tests/BenchmarkTests/BenchmarkReporterTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkReporterTests.swift
@@ -32,8 +32,8 @@ final class BenchmarkReporterTests: XCTestCase {
         let expected = #"""
         name                   time std        iterations
         -------------------------------------------------
-        My Suite: fast    1500.0 ns ±  47.14 % 2
-        My Suite: slow 1500000.0 ns ±  47.14 % 2
+        My Suite: fast    1500.0 ns ±  47.14 %          2
+        My Suite: slow 1500000.0 ns ±  47.14 %          2
         """#.split(separator: "\n").map { String($0) }
 
 

--- a/Tests/BenchmarkTests/BenchmarkReporterTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkReporterTests.swift
@@ -29,12 +29,12 @@ final class BenchmarkReporterTests: XCTestCase {
 
         reporter.report(results: results)
 
-        let expected = #"""
-        name           time         std        iterations
-        -------------------------------------------------
-        My Suite: fast    1500.0 ns ±  47.14 %          2
-        My Suite: slow 1500000.0 ns ±  47.14 %          2
-        """#.split(separator: "\n").map { String($0) }
+        let expected = """
+        name          \ttime        \tstd       \titerations
+        --------------\t------------\t----------\t----------
+        My Suite: fast\t   1500.0 ns\t±  47.14 %\t         2
+        My Suite: slow\t1500000.0 ns\t±  47.14 %\t         2
+        """.split(separator: "\n").map { String($0) }
 
         let actual = output.lines.map {$0.trimmingCharacters(in: .whitespacesAndNewlines) }
                                  .filter { !$0.isEmpty}

--- a/Tests/BenchmarkTests/BenchmarkReporterTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkReporterTests.swift
@@ -18,6 +18,30 @@ import XCTest
 
 final class BenchmarkReporterTests: XCTestCase {
     func testPlainTextReporter() throws {
+        let results: [BenchmarkResult] = [
+            BenchmarkResult(benchmarkName: "fast", suiteName: "My Suite", measurements: [1_000, 2_000]),
+            BenchmarkResult(benchmarkName: "slow", suiteName: "My Suite", measurements: [1_000_000, 2_000_000])
+
+        ]
+
+        let output = MockTextOutputStream()
+        var reporter = PlainTextReporter(to: output)
+
+        reporter.report(results: results)
+
+        let expected = #"""
+        name                   time std        iterations
+        -------------------------------------------------
+        My Suite: fast    1500.0 ns ±  47.14 % 2
+        My Suite: slow 1500000.0 ns ±  47.14 % 2
+        """#.split(separator: "\n").map { String($0) }
+
+
+        let actual = output.lines.map {$0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                                 .filter { !$0.isEmpty}
+        for (expectedLine, actualLine) in zip(expected, actual) {
+            XCTAssertEqual(expectedLine, actualLine)
+        }
 
     }
 

--- a/Tests/BenchmarkTests/BenchmarkReporterTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkReporterTests.swift
@@ -17,36 +17,11 @@ import XCTest
 @testable import Benchmark
 
 final class BenchmarkReporterTests: XCTestCase {
+    func testPlainTextReporter() throws {
 
-    func testPaddingLeft() throws {
-        let testText = "testText"
-        XCTAssertEqual(testText.leftPadding(toLength: testText.count, withPad:" "), "testText")
-        XCTAssertEqual(testText.leftPadding(toLength: testText.count + 3, withPad:" "), "   testText")
-    }
-
-    func testPaddingEachCell() throws {
-        let dummyName = ["00", "10", "20"]
-        let dummyTime = ["01", "11", "21"]
-        let dummyStd = ["02", "12", "22"]
-        let dummyIterations = ["03", "13", "23"]
-        let columuns = [dummyName, dummyTime, dummyStd, dummyIterations]
-
-        for index in 0..<dummyName.count {
-            for columnIndex in 0..<columuns.count {
-                let cell = columuns[columnIndex][index]
-                let paddedCell = paddingEachCell(cell: cell,
-                    index: index, columnIndex: columnIndex, length: cell.count + 1)
-                if index != 0 && columnIndex == 1 {
-                    XCTAssertEqual(paddedCell, " \(index)\(columnIndex)")
-                } else {
-                    XCTAssertEqual(paddedCell, "\(index)\(columnIndex) ")
-                }
-            }
-        }
     }
 
     static var allTests = [
-        ("testPaddingLeft", testPaddingLeft),
-        ("testPaddingEachCell", testPaddingEachCell)
+        ("PlainTextReporter", testPlainTextReporter),
     ]
 }

--- a/Tests/BenchmarkTests/MockTextOutputStream.swift
+++ b/Tests/BenchmarkTests/MockTextOutputStream.swift
@@ -12,18 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public func main(_ suites: [BenchmarkSuite]) {
-    let command = BenchmarkCommand.parseOrExit()
-    let settings = command.settings
-    let reporter = PlainTextReporter(to: StdoutOutputStream())
+final class MockTextOutputStream: TextOutputStream {
+    public private(set) var lines: [String] = []
 
-    var runner = BenchmarkRunner(
-        suites: suites,
-        settings: settings,
-        reporter: reporter)
-    try! runner.run()
-}
-
-public func main() {
-    main([defaultBenchmarkSuite])
+    func write(_ string: String) {
+        guard !string.isEmpty else { return }
+        lines.append(string)
+    }
 }


### PR DESCRIPTION
This is a follow-up to #28, which a few problems:

- "Triggar" is misspelled, and is returned as a sentinel value for an invalid call to `leftPadding(toLength:withPad:)`

https://github.com/google/swift-benchmark/commit/a287f4de0413e4ad16db0f66c73e1a4bf44fa2bc#diff-9b05fa5d59da27a6fe31d0971c0d4a29R26

- The implementation of `leftPadding(toLength:withPad:)` breaks if the padding string has a length other than 1.

https://github.com/google/swift-benchmark/commit/a287f4de0413e4ad16db0f66c73e1a4bf44fa2bc#diff-9b05fa5d59da27a6fe31d0971c0d4a29R21

- `leftPadding(toLength:withPad:)` invokes `fatalError` on invalid input

https://github.com/google/swift-benchmark/commit/a287f4de0413e4ad16db0f66c73e1a4bf44fa2bc#diff-9b05fa5d59da27a6fe31d0971c0d4a29R28

- The actual output of `PlainTextReporter` isn't tested

https://github.com/google/swift-benchmark/commit/a287f4de0413e4ad16db0f66c73e1a4bf44fa2bc#diff-b7fe1cac55740b9c8e5819e9a1cadab3R21-R52

This PR refactors `PlainTextReporter` to be testable. It also introduces an internal `Column` type to make the table construction more resilient and extensible.