### PR TITLE
Add support for lower overhead measurement loop

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,8 @@
 
 import PackageDescription
 
+let optimize = [SwiftSetting.unsafeFlags(["-cross-module-optimization", "-O"])]
+
 let package = Package(
     name: "Benchmark",
     products: [
@@ -29,15 +31,19 @@ let package = Package(
     targets: [
         .target(
             name: "Benchmark",
-            dependencies: [.product(name: "ArgumentParser", package: "swift-argument-parser")]),
+            dependencies: [.product(name: "ArgumentParser", package: "swift-argument-parser")],
+            swiftSettings: optimize),
         .target(
             name: "BenchmarkMinimalExample",
-            dependencies: ["Benchmark"]),
+            dependencies: ["Benchmark"],
+            swiftSettings: optimize),
         .target(
             name: "BenchmarkSuiteExample",
-            dependencies: ["Benchmark"]),
+            dependencies: ["Benchmark"],
+            swiftSettings: optimize),
         .testTarget(
             name: "BenchmarkTests",
-            dependencies: ["Benchmark", "BenchmarkSuiteExample"]),
+            dependencies: ["Benchmark", "BenchmarkSuiteExample"],
+            swiftSettings: optimize),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,6 @@
 
 import PackageDescription
 
-let optimize = [SwiftSetting.unsafeFlags(["-cross-module-optimization", "-O"])]
-
 let package = Package(
     name: "Benchmark",
     products: [
@@ -31,19 +29,15 @@ let package = Package(
     targets: [
         .target(
             name: "Benchmark",
-            dependencies: [.product(name: "ArgumentParser", package: "swift-argument-parser")],
-            swiftSettings: optimize),
+            dependencies: [.product(name: "ArgumentParser", package: "swift-argument-parser")]),
         .target(
             name: "BenchmarkMinimalExample",
-            dependencies: ["Benchmark"],
-            swiftSettings: optimize),
+            dependencies: ["Benchmark"]),
         .target(
             name: "BenchmarkSuiteExample",
-            dependencies: ["Benchmark"],
-            swiftSettings: optimize),
+            dependencies: ["Benchmark"]),
         .testTarget(
             name: "BenchmarkTests",
-            dependencies: ["Benchmark", "BenchmarkSuiteExample"],
-            swiftSettings: optimize),
+            dependencies: ["Benchmark", "BenchmarkSuiteExample"]),
     ]
 )

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -16,7 +16,7 @@ public protocol AnyBenchmark {
     var name: String { get }
     var settings: [BenchmarkSetting] { get }
     func setUp()
-    func run(_ state: inout BenchmarkState)
+    func run(_ state: inout BenchmarkState) throws
     func tearDown()
 }
 
@@ -28,55 +28,55 @@ extension AnyBenchmark {
 internal class ClosureBenchmark: AnyBenchmark {
     let name: String
     let settings: [BenchmarkSetting]
-    let closure: () -> Void
+    let closure: () throws -> Void
 
-    init(_ name: String, settings: [BenchmarkSetting], closure: @escaping () -> Void) {
+    init(_ name: String, settings: [BenchmarkSetting], closure: @escaping () throws -> Void) {
         self.name = name
         self.settings = settings
         self.closure = closure
     }
 
-    func run(_ state: inout BenchmarkState) {
-        return self.closure()
+    func run(_ state: inout BenchmarkState) throws {
+        return try self.closure()
     }
 }
 
 internal class InoutClosureBenchmark: AnyBenchmark {
     let name: String
     let settings: [BenchmarkSetting]
-    let closure: (inout BenchmarkState) -> Void
+    let closure: (inout BenchmarkState) throws -> Void
 
     init(
         _ name: String, settings: [BenchmarkSetting],
-        closure: @escaping (inout BenchmarkState) -> Void
+        closure: @escaping (inout BenchmarkState) throws -> Void
     ) {
         self.name = name
         self.settings = settings
         self.closure = closure
     }
 
-    func run(_ state: inout BenchmarkState) {
-        return self.closure(&state)
+    func run(_ state: inout BenchmarkState) throws {
+        return try self.closure(&state)
     }
 }
 
-public func benchmark(_ name: String, function: @escaping () -> Void) {
+public func benchmark(_ name: String, function: @escaping () throws -> Void) {
     defaultBenchmarkSuite.benchmark(name, function: function)
 }
 
-public func benchmark(_ name: String, function: @escaping (inout BenchmarkState) -> Void) {
+public func benchmark(_ name: String, function: @escaping (inout BenchmarkState) throws -> Void) {
     defaultBenchmarkSuite.benchmark(name, function: function)
 }
 
 public func benchmark(
-    _ name: String, settings: BenchmarkSetting..., function: @escaping () -> Void
+    _ name: String, settings: BenchmarkSetting..., function: @escaping () throws -> Void
 ) {
     defaultBenchmarkSuite.benchmark(name, settings: settings, function: function)
 }
 
 public func benchmark(
     _ name: String, settings: BenchmarkSetting...,
-    function: @escaping (inout BenchmarkState) -> Void
+    function: @escaping (inout BenchmarkState) throws -> Void
 ) {
     defaultBenchmarkSuite.benchmark(name, settings: settings, function: function)
 }

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -16,7 +16,7 @@ public protocol AnyBenchmark {
     var name: String { get }
     var settings: [BenchmarkSetting] { get }
     func setUp()
-    func run()
+    func run(_ state: inout BenchmarkState)
     func tearDown()
 }
 
@@ -36,8 +36,24 @@ internal class ClosureBenchmark: AnyBenchmark {
         self.closure = closure
     }
 
-    func run() {
+    func run(_ state: inout BenchmarkState) {
         return self.closure()
+    }
+}
+
+internal class InoutClosureBenchmark: AnyBenchmark {
+    let name: String
+    let settings: [BenchmarkSetting]
+    let closure: (inout BenchmarkState) -> Void
+
+    init(_ name: String, settings: [BenchmarkSetting], closure: @escaping (inout BenchmarkState) -> Void) {
+        self.name = name
+        self.settings = settings
+        self.closure = closure
+    }
+
+    func run(_ state: inout BenchmarkState) {
+        return self.closure(&state)
     }
 }
 
@@ -45,8 +61,19 @@ public func benchmark(_ name: String, function: @escaping () -> Void) {
     defaultBenchmarkSuite.benchmark(name, function: function)
 }
 
+public func benchmark(_ name: String, function: @escaping (inout BenchmarkState) -> Void) {
+    defaultBenchmarkSuite.benchmark(name, function: function)
+}
+
 public func benchmark(
     _ name: String, settings: BenchmarkSetting..., function: @escaping () -> Void
+) {
+    defaultBenchmarkSuite.benchmark(name, settings: settings, function: function)
+}
+
+
+public func benchmark(
+    _ name: String, settings: BenchmarkSetting..., function: @escaping (inout BenchmarkState) -> Void
 ) {
     defaultBenchmarkSuite.benchmark(name, settings: settings, function: function)
 }

--- a/Sources/Benchmark/Benchmark.swift
+++ b/Sources/Benchmark/Benchmark.swift
@@ -46,7 +46,10 @@ internal class InoutClosureBenchmark: AnyBenchmark {
     let settings: [BenchmarkSetting]
     let closure: (inout BenchmarkState) -> Void
 
-    init(_ name: String, settings: [BenchmarkSetting], closure: @escaping (inout BenchmarkState) -> Void) {
+    init(
+        _ name: String, settings: [BenchmarkSetting],
+        closure: @escaping (inout BenchmarkState) -> Void
+    ) {
         self.name = name
         self.settings = settings
         self.closure = closure
@@ -71,9 +74,9 @@ public func benchmark(
     defaultBenchmarkSuite.benchmark(name, settings: settings, function: function)
 }
 
-
 public func benchmark(
-    _ name: String, settings: BenchmarkSetting..., function: @escaping (inout BenchmarkState) -> Void
+    _ name: String, settings: BenchmarkSetting...,
+    function: @escaping (inout BenchmarkState) -> Void
 ) {
     defaultBenchmarkSuite.benchmark(name, settings: settings, function: function)
 }

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -140,7 +140,7 @@ public struct BenchmarkRunner {
         var state = BenchmarkState(iterations: n, settings: settings)
         do {
             try state.loop(benchmark)
-        } catch is Termination {
+        } catch is BenchmarkTermination {
         } catch {
             fatalError("Unexpected error: \(error).")
         }

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -134,17 +134,22 @@ public struct BenchmarkRunner {
     }
 
     func doNIterations(_ n: Int, benchmark: AnyBenchmark, suite: BenchmarkSuite) -> [Double] {
-        var clock = BenchmarkClock()
+        var state = BenchmarkState(iterations: n)
         var measurements: [Double] = []
         measurements.reserveCapacity(n)
+        var clock: BenchmarkClock = BenchmarkClock()
 
         for _ in 1...n {
             benchmark.setUp()
             clock.recordStart()
-            benchmark.run()
+            benchmark.run(&state)
             clock.recordEnd()
             benchmark.tearDown()
-            measurements.append(Double(clock.elapsed))
+            if state.measurements.count > 0 {
+                return state.measurements
+            } else {
+                measurements.append(Double(clock.elapsed))
+            }
         }
 
         return measurements

--- a/Sources/Benchmark/BenchmarkState.swift
+++ b/Sources/Benchmark/BenchmarkState.swift
@@ -12,32 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Dispatch
-
-struct BenchmarkClock {
-    var start: UInt64 = 0
-    var end: UInt64 = 0
+public struct BenchmarkState {
+    var iterations: Int
+    var measurements: [Double]
 
     @inline(__always)
-    init() {}
-
-    @inline(__always)
-    static func now() -> UInt64 {
-        return DispatchTime.now().uptimeNanoseconds
+    init(iterations: Int) {
+        self.iterations = iterations
+        self.measurements = []
     }
 
     @inline(__always)
-    mutating func recordStart() {
-        start = BenchmarkClock.now()
-    }
+    public mutating func measure(f: () -> ()) {
+        var result: [Double] = []
+        result.reserveCapacity(iterations)
+        var clock: BenchmarkClock = BenchmarkClock()
 
-    @inline(__always)
-    mutating func recordEnd() {
-        end = BenchmarkClock.now()
-    }
+        for _ in 1...iterations {
+            clock.recordStart()
+            f()
+            clock.recordEnd()
+            result.append(Double(clock.elapsed))
+        }
 
-    @inline(__always)
-    var elapsed: UInt64 {
-        return end - start
+        self.measurements = result
     }
 }

--- a/Sources/Benchmark/BenchmarkState.swift
+++ b/Sources/Benchmark/BenchmarkState.swift
@@ -23,7 +23,7 @@ public struct BenchmarkState {
     }
 
     @inline(__always)
-    public mutating func measure(f: () -> ()) {
+    public mutating func measure(f: () -> Void) {
         var result: [Double] = []
         result.reserveCapacity(iterations)
         var clock: BenchmarkClock = BenchmarkClock()

--- a/Sources/Benchmark/BenchmarkState.swift
+++ b/Sources/Benchmark/BenchmarkState.swift
@@ -83,7 +83,7 @@ public struct BenchmarkState {
 
     /// Run the closure within within benchmark measurement section.
     /// It may throw errors to propagate early termination to 
-    //i/ the outer benchmark loop.
+    /// the outer benchmark loop.
     @inline(__always)
     public mutating func measure(f: () -> Void) throws {
         start()

--- a/Sources/Benchmark/BenchmarkState.swift
+++ b/Sources/Benchmark/BenchmarkState.swift
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-struct Termination: Error {}
-
 /// Benchmark state is used to collect the 
 /// benchmark measurements and view the settings it 
 /// was configured with.
@@ -63,7 +61,7 @@ public struct BenchmarkState {
         if measurements.count < iterations {
             measurements.append(self.duration)
         } else {
-            throw Termination()
+            throw BenchmarkTermination()
         }
     }
 

--- a/Sources/Benchmark/BenchmarkSuite.swift
+++ b/Sources/Benchmark/BenchmarkSuite.swift
@@ -62,7 +62,8 @@ public class BenchmarkSuite {
     }
 
     public func benchmark(
-        _ name: String, settings: BenchmarkSetting..., function f: @escaping (inout BenchmarkState) -> Void
+        _ name: String, settings: BenchmarkSetting...,
+        function f: @escaping (inout BenchmarkState) -> Void
     ) {
         let benchmark = InoutClosureBenchmark(name, settings: settings, closure: f)
         register(benchmark: benchmark)
@@ -76,7 +77,8 @@ public class BenchmarkSuite {
     }
 
     public func benchmark(
-        _ name: String, settings: [BenchmarkSetting], function f: @escaping (inout BenchmarkState) -> Void
+        _ name: String, settings: [BenchmarkSetting],
+        function f: @escaping (inout BenchmarkState) -> Void
     ) {
         let benchmark = InoutClosureBenchmark(name, settings: settings, closure: f)
         register(benchmark: benchmark)

--- a/Sources/Benchmark/BenchmarkSuite.swift
+++ b/Sources/Benchmark/BenchmarkSuite.swift
@@ -49,6 +49,11 @@ public class BenchmarkSuite {
         register(benchmark: benchmark)
     }
 
+    public func benchmark(_ name: String, function f: @escaping (inout BenchmarkState) -> Void) {
+        let benchmark = InoutClosureBenchmark(name, settings: [], closure: f)
+        register(benchmark: benchmark)
+    }
+
     public func benchmark(
         _ name: String, settings: BenchmarkSetting..., function f: @escaping () -> Void
     ) {
@@ -57,9 +62,23 @@ public class BenchmarkSuite {
     }
 
     public func benchmark(
+        _ name: String, settings: BenchmarkSetting..., function f: @escaping (inout BenchmarkState) -> Void
+    ) {
+        let benchmark = InoutClosureBenchmark(name, settings: settings, closure: f)
+        register(benchmark: benchmark)
+    }
+
+    public func benchmark(
         _ name: String, settings: [BenchmarkSetting], function f: @escaping () -> Void
     ) {
         let benchmark = ClosureBenchmark(name, settings: settings, closure: f)
+        register(benchmark: benchmark)
+    }
+
+    public func benchmark(
+        _ name: String, settings: [BenchmarkSetting], function f: @escaping (inout BenchmarkState) -> Void
+    ) {
+        let benchmark = InoutClosureBenchmark(name, settings: settings, closure: f)
         register(benchmark: benchmark)
     }
 }

--- a/Sources/Benchmark/BenchmarkSuite.swift
+++ b/Sources/Benchmark/BenchmarkSuite.swift
@@ -44,18 +44,20 @@ public class BenchmarkSuite {
         benchmarks.append(benchmark)
     }
 
-    public func benchmark(_ name: String, function f: @escaping () -> Void) {
+    public func benchmark(_ name: String, function f: @escaping () throws -> Void) {
         let benchmark = ClosureBenchmark(name, settings: [], closure: f)
         register(benchmark: benchmark)
     }
 
-    public func benchmark(_ name: String, function f: @escaping (inout BenchmarkState) -> Void) {
+    public func benchmark(
+        _ name: String, function f: @escaping (inout BenchmarkState) throws -> Void
+    ) {
         let benchmark = InoutClosureBenchmark(name, settings: [], closure: f)
         register(benchmark: benchmark)
     }
 
     public func benchmark(
-        _ name: String, settings: BenchmarkSetting..., function f: @escaping () -> Void
+        _ name: String, settings: BenchmarkSetting..., function f: @escaping () throws -> Void
     ) {
         let benchmark = ClosureBenchmark(name, settings: settings, closure: f)
         register(benchmark: benchmark)
@@ -63,14 +65,14 @@ public class BenchmarkSuite {
 
     public func benchmark(
         _ name: String, settings: BenchmarkSetting...,
-        function f: @escaping (inout BenchmarkState) -> Void
+        function f: @escaping (inout BenchmarkState) throws -> Void
     ) {
         let benchmark = InoutClosureBenchmark(name, settings: settings, closure: f)
         register(benchmark: benchmark)
     }
 
     public func benchmark(
-        _ name: String, settings: [BenchmarkSetting], function f: @escaping () -> Void
+        _ name: String, settings: [BenchmarkSetting], function f: @escaping () throws -> Void
     ) {
         let benchmark = ClosureBenchmark(name, settings: settings, closure: f)
         register(benchmark: benchmark)
@@ -78,7 +80,7 @@ public class BenchmarkSuite {
 
     public func benchmark(
         _ name: String, settings: [BenchmarkSetting],
-        function f: @escaping (inout BenchmarkState) -> Void
+        function f: @escaping (inout BenchmarkState) throws -> Void
     ) {
         let benchmark = InoutClosureBenchmark(name, settings: settings, closure: f)
         register(benchmark: benchmark)

--- a/Sources/Benchmark/BenchmarkTermination.swift
+++ b/Sources/Benchmark/BenchmarkTermination.swift
@@ -1,0 +1,15 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+struct BenchmarkTermination: Error {}

--- a/Sources/Benchmark/BenchmarkTime.swift
+++ b/Sources/Benchmark/BenchmarkTime.swift
@@ -14,30 +14,7 @@
 
 import Dispatch
 
-struct BenchmarkClock {
-    var start: UInt64 = 0
-    var end: UInt64 = 0
-
-    @inline(__always)
-    init() {}
-
-    @inline(__always)
-    static func now() -> UInt64 {
-        return DispatchTime.now().uptimeNanoseconds
-    }
-
-    @inline(__always)
-    mutating func recordStart() {
-        start = BenchmarkClock.now()
-    }
-
-    @inline(__always)
-    mutating func recordEnd() {
-        end = BenchmarkClock.now()
-    }
-
-    @inline(__always)
-    var elapsed: UInt64 {
-        return end - start
-    }
+@inline(__always)
+func now() -> UInt64 {
+    return DispatchTime.now().uptimeNanoseconds
 }

--- a/Sources/Benchmark/CMakeLists.txt
+++ b/Sources/Benchmark/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_library(Benchmark
   Benchmark.swift
   BenchmarkArguments.swift
-  BenchmarkClock.swift
   BenchmarkCommand.swift
   BenchmarkFilter.swift
   BenchmarkMain.swift
@@ -11,8 +10,10 @@ add_library(Benchmark
   BenchmarkSetting.swift
   BenchmarkState.swift
   BenchmarkSuite.swift
-  MakeTests.swift
-  Stats.swift)
+  BenchmarkTermination.swift
+  BenchmarkTime.swift
+  Stats.swift
+  TestIntegration.swift)
 # NOTE: workaround for CMake <3.17 which does not propagate the property
 set_target_properties(Benchmark PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/Benchmark/CMakeLists.txt
+++ b/Sources/Benchmark/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(Benchmark
   BenchmarkResult.swift
   BenchmarkRunner.swift
   BenchmarkSetting.swift
+  BenchmarkState.swift
   BenchmarkSuite.swift
   MakeTests.swift
   Stats.swift)

--- a/Sources/Benchmark/TestIntegration.swift
+++ b/Sources/Benchmark/TestIntegration.swift
@@ -16,7 +16,8 @@
 public func runTests(suites: [BenchmarkSuite]) {
     for suite in suites {
         for benchmark in suite.benchmarks {
-            benchmark.run()
+            var state = BenchmarkState(iterations: 1)
+            benchmark.run(&state)
         }
     }
 }
@@ -31,7 +32,8 @@ public func makeTests<T>(_ type: T.Type, suites: [BenchmarkSuite]) -> [(String, 
             let name = "\(suite.name): \(benchmark.name)"
             let closure: (T) -> () -> Void = { _ in
                 return {
-                    benchmark.run()
+                    var state = BenchmarkState(iterations: 1)
+                    benchmark.run(&state)
                     return
                 }
             }

--- a/Sources/Benchmark/TestIntegration.swift
+++ b/Sources/Benchmark/TestIntegration.swift
@@ -16,8 +16,13 @@
 public func runTests(suites: [BenchmarkSuite]) {
     for suite in suites {
         for benchmark in suite.benchmarks {
-            var state = BenchmarkState(iterations: 1)
-            benchmark.run(&state)
+            var state = BenchmarkState(iterations: 1, settings: BenchmarkSettings())
+            do {
+                try benchmark.run(&state)
+            } catch is Termination {
+            } catch {
+                fatalError("Unexpected error: \(error).")
+            }
         }
     }
 }
@@ -32,8 +37,13 @@ public func makeTests<T>(_ type: T.Type, suites: [BenchmarkSuite]) -> [(String, 
             let name = "\(suite.name): \(benchmark.name)"
             let closure: (T) -> () -> Void = { _ in
                 return {
-                    var state = BenchmarkState(iterations: 1)
-                    benchmark.run(&state)
+                    var state = BenchmarkState(iterations: 1, settings: BenchmarkSettings())
+                    do {
+                        try benchmark.run(&state)
+                    } catch is Termination {
+                    } catch {
+                        fatalError("Unexpected error: \(error).")
+                    }
                     return
                 }
             }

--- a/Sources/Benchmark/TestIntegration.swift
+++ b/Sources/Benchmark/TestIntegration.swift
@@ -19,7 +19,7 @@ public func runTests(suites: [BenchmarkSuite]) {
             var state = BenchmarkState(iterations: 1, settings: BenchmarkSettings())
             do {
                 try benchmark.run(&state)
-            } catch is Termination {
+            } catch is BenchmarkTermination {
             } catch {
                 fatalError("Unexpected error: \(error).")
             }
@@ -40,7 +40,7 @@ public func makeTests<T>(_ type: T.Type, suites: [BenchmarkSuite]) -> [(String, 
                     var state = BenchmarkState(iterations: 1, settings: BenchmarkSettings())
                     do {
                         try benchmark.run(&state)
-                    } catch is Termination {
+                    } catch is BenchmarkTermination {
                     } catch {
                         fatalError("Unexpected error: \(error).")
                     }

--- a/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
@@ -39,6 +39,27 @@ final class BenchmarkRunnerTests: XCTestCase {
             runBenchmarks(settings: settings))
     }
 
+    func testStateMeasure() throws {
+        let suite = BenchmarkSuite(name: "Suite")
+        suite.benchmark("noop") {}
+        suite.benchmark("state measure noop") { state in
+            state.measure {}
+        }
+
+        var runner = BenchmarkRunner(
+            suites: [suite],
+            settings: [.iterations(100000)],
+            reporter: BlackHoleReporter())
+        try runner.run()
+
+        let noopResults = runner.results[0].measurements
+        let measureNoopResults = runner.results[1].measurements
+
+        XCTAssertEqual(noopResults.count, 100000)
+        XCTAssertEqual(measureNoopResults.count, 100000)
+        XCTAssertTrue(noopResults.sum > measureNoopResults.sum)
+    }
+
     static var allTests = [
         ("testFilterBenchmarksSuffix", testFilterBenchmarksSuffix),
         ("testFilterBenchmarksSuiteName", testFilterBenchmarksSuiteName),

--- a/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
@@ -62,6 +62,13 @@ final class BenchmarkRunnerTests: XCTestCase {
             }
         }
 
+        suite.benchmark("measure uneven iterations noop") { state in
+            for _ in 1...1337 {
+                try state.measure {
+                }
+            }
+        }
+
         var runner = BenchmarkRunner(
             suites: [suite],
             settings: [Iterations(100000)],

--- a/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
@@ -74,7 +74,6 @@ final class BenchmarkRunnerTests: XCTestCase {
         XCTAssertEqual(noopResults.count, 100000)
         for customResult in customResults {
             XCTAssertEqual(customResult.count, 100000)
-            XCTAssertTrue(noopResults.sum > customResult.sum)
         }
     }
 

--- a/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
@@ -89,6 +89,7 @@ final class BenchmarkRunnerTests: XCTestCase {
         ("testFilterBenchmarksSuiteName", testFilterBenchmarksSuiteName),
         ("testFilterBenchmarksFullName", testFilterBenchmarksFullName),
         ("testAutomaticallyDetectIterations", testAutomaticallyDetectIterations),
+        ("testCustomMeasurements", testCustomMeasurements),
     ]
 }
 

--- a/Tests/BenchmarkTests/CustomBenchmarkTests.swift
+++ b/Tests/BenchmarkTests/CustomBenchmarkTests.swift
@@ -50,7 +50,7 @@ fileprivate class MockBenchmark: AnyBenchmark {
         didSetUp = true
     }
 
-    func run() {
+    func run(_ state: inout BenchmarkState) {
         didRun = true
     }
 


### PR DESCRIPTION
This change adds support for lower-overhead version of writing explicit measurement loop within the benchmark itself:

```swift
benchmark("my bench") { state in
    // set-up, not measured

    state.measure {
        // body of the benchmark, runs #iterations times
    }

    // tear-down, not measured
}
```

By using measure we get less overhead of measurements by around 10%:

```
    $ swift run -c release BenchmarkMinimalExample --min-time 10
    --max-iterations 100000000
    Updating https://github.com/apple/swift-argument-parser
    Resolving https://github.com/apple/swift-argument-parser at 0.0.6
    [4/4] Linking BenchmarkMinimalExample
    running noop... done! (6095.58 ms)
    running measure noop... done! (5549.44 ms)

    name            time    std         iterations
    ----------------------------------------------
    noop            23.0 ns ±  83.88 %   100000000
    measure noop    21.0 ns ±  88.80 %   100000000
```

`state.measure` has the same precision as if the clock is used directly in a tight loop without any closures. To improve precision further we would need to provide a higher precision clock than the one provided by DispatchTime.

Fixes #29