### PR TITLE
Add support for user-defined settings

### DIFF
--- a/Sources/Benchmark/BenchmarkArguments.swift
+++ b/Sources/Benchmark/BenchmarkArguments.swift
@@ -1,0 +1,99 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ArgumentParser
+
+/// A bundle of command-line arguments.
+public struct BenchmarkArguments: ParsableArguments {
+    @Flag(help: "Overrides check to verify optimized build.")
+    var allowDebugBuild: Bool
+
+    @Option(help: "Run only benchmarks whose names match the regular expression.")
+    var filter: String?
+
+    @Option(help: "Number of iterations to run.")
+    var iterations: Int?
+
+    @Option(help: "Number of warm-up iterations to run.")
+    var warmupIterations: Int?
+
+    @Option(help: "Minimal time to run when automatically detecting number iterations.")
+    var minTime: Double?
+
+    @Option(
+        help: "Maximum number of iterations to run when automatically detecting number iterations.")
+    var maxIterations: Int?
+
+    public init() {}
+
+    public var settings: [BenchmarkSetting] {
+        var result: [BenchmarkSetting] = []
+
+        if let value = filter {
+            result.append(Filter(value))
+        }
+        if let value = iterations {
+            result.append(Iterations(value))
+        }
+        if let value = warmupIterations {
+            result.append(WarmupIterations(value))
+        }
+        if let value = minTime {
+            result.append(MinTime(seconds: value))
+        }
+        if let value = maxIterations {
+            result.append(MaxIterations(value))
+        }
+
+        return result
+    }
+
+    public mutating func validate() throws {
+        var isDebug = false
+        assert(
+            {
+                isDebug = true
+                return true
+            }())
+        if isDebug && !allowDebugBuild {
+            throw ValidationError(debugBuildErrorMessage)
+        }
+        if iterations != nil && iterations! <= 0 {
+            throw ValidationError(positiveNumberError(flag: "--iterations", of: "integer"))
+        }
+        if warmupIterations != nil && warmupIterations! <= 0 {
+            throw ValidationError(positiveNumberError(flag: "--warmup-iterations", of: "integer"))
+        }
+        if maxIterations != nil && maxIterations! <= 0 {
+            throw ValidationError(positiveNumberError(flag: "--max-iterations", of: "integer"))
+        }
+        if minTime != nil && minTime! <= 0 {
+            throw ValidationError(
+                positiveNumberError(flag: "--min-time", of: "floating point number"))
+        }
+    }
+
+    var debugBuildErrorMessage: String {
+        """
+        Please build with optimizations enabled (`-c release` if using SwiftPM,
+        `-c opt` if using bazel, or `-O` if using swiftc directly). If you would really
+        like to run the benchmark without optimizations, pass the `--allow-debug-build`
+        flag.
+        """
+    }
+
+    func positiveNumberError(flag: String, of type: String) -> String {
+        return "Value provided via \(flag) must be a positive \(type)."
+    }
+}

--- a/Sources/Benchmark/BenchmarkArguments.swift
+++ b/Sources/Benchmark/BenchmarkArguments.swift
@@ -14,7 +14,8 @@
 
 import ArgumentParser
 
-/// A bundle of command-line arguments.
+/// A bundle of command-line arguments, that includes
+/// all of the default benchmark settings. 
 public struct BenchmarkArguments: ParsableArguments {
     @Flag(help: "Overrides check to verify optimized build.")
     var allowDebugBuild: Bool
@@ -37,6 +38,7 @@ public struct BenchmarkArguments: ParsableArguments {
 
     public init() {}
 
+    /// Conversion from command-line arguments to benchmark settings.
     public var settings: [BenchmarkSetting] {
         var result: [BenchmarkSetting] = []
 
@@ -59,6 +61,7 @@ public struct BenchmarkArguments: ParsableArguments {
         return result
     }
 
+    /// Validate that all arguments are well-formed, or throw otherwise. 
     public mutating func validate() throws {
         var isDebug = false
         assert(

--- a/Sources/Benchmark/BenchmarkCommand.swift
+++ b/Sources/Benchmark/BenchmarkCommand.swift
@@ -13,86 +13,14 @@
 // limitations under the License.
 
 import ArgumentParser
-import Foundation
 
 /// Allows dynamic configuration of the benchmark execution.
 internal struct BenchmarkCommand: ParsableCommand {
-    @Flag(help: "Overrides check to verify optimized build.")
-    var allowDebugBuild: Bool
-
-    @Option(help: "Run only benchmarks whose names match the regular expression.")
-    var filter: String?
-
-    @Option(help: "Number of iterations to run.")
-    var iterations: Int?
-
-    @Option(help: "Number of warm-up iterations to run.")
-    var warmupIterations: Int?
-
-    @Option(help: "Minimal time to run when automatically detecting number iterations.")
-    var minTime: Double?
-
-    @Option(
-        help: "Maximum number of iterations to run when automatically detecting number iterations.")
-    var maxIterations: Int?
-
-    var settings: [BenchmarkSetting] {
-        var result: [BenchmarkSetting] = []
-
-        if let value = filter {
-            result.append(.filter(value))
-        }
-        if let value = iterations {
-            result.append(.iterations(value))
-        }
-        if let value = warmupIterations {
-            result.append(.warmupIterations(value))
-        }
-        if let value = minTime {
-            result.append(.minTime(seconds: value))
-        }
-        if let value = maxIterations {
-            result.append(.maxIterations(value))
-        }
-
-        return result
-    }
+    @OptionGroup()
+    var arguments: BenchmarkArguments
 
     mutating func validate() throws {
-        var isDebug = false
-        assert(
-            {
-                isDebug = true
-                return true
-            }())
-        if isDebug && !allowDebugBuild {
-            throw ValidationError(debugBuildErrorMessage)
-        }
-        if iterations != nil && iterations! <= 0 {
-            throw ValidationError(positiveNumberError(flag: "--iterations", of: "integer"))
-        }
-        if warmupIterations != nil && warmupIterations! <= 0 {
-            throw ValidationError(positiveNumberError(flag: "--warmup-iterations", of: "integer"))
-        }
-        if maxIterations != nil && maxIterations! <= 0 {
-            throw ValidationError(positiveNumberError(flag: "--max-iterations", of: "integer"))
-        }
-        if minTime != nil && minTime! <= 0 {
-            throw ValidationError(
-                positiveNumberError(flag: "--min-time", of: "floating point number"))
-        }
+        try arguments.validate()
     }
 
-    var debugBuildErrorMessage: String {
-        """
-        Please build with optimizations enabled (`-c release` if using SwiftPM,
-        `-c opt` if using bazel, or `-O` if using swiftc directly). If you would really
-        like to run the benchmark without optimizations, pass the `--allow-debug-build`
-        flag.
-        """
-    }
-
-    func positiveNumberError(flag: String, of type: String) -> String {
-        return "Value provided via \(flag) must be a positive \(type)."
-    }
 }

--- a/Sources/Benchmark/BenchmarkMain.swift
+++ b/Sources/Benchmark/BenchmarkMain.swift
@@ -14,7 +14,10 @@
 
 public func main(_ suites: [BenchmarkSuite]) {
     let command = BenchmarkCommand.parseOrExit()
-    let settings = command.settings
+    main(suites, settings: command.arguments.settings)
+}
+
+public func main(_ suites: [BenchmarkSuite], settings: [BenchmarkSetting]) {
     let reporter = PlainTextReporter(to: StdoutOutputStream())
 
     var runner = BenchmarkRunner(

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -38,14 +38,15 @@ public struct BenchmarkRunner {
     }
 
     mutating func run(benchmark: AnyBenchmark, suite: BenchmarkSuite) throws {
-        let settings = try BenchmarkSettings([
+        let settings = BenchmarkSettings([
             defaultSettings,
             self.settings,
             suite.settings,
             benchmark.settings,
         ])
 
-        if !settings.filter.matches(suiteName: suite.name, benchmarkName: benchmark.name) {
+        let filter = try BenchmarkFilter(settings.filter)
+        if !filter.matches(suiteName: suite.name, benchmarkName: benchmark.name) {
             return
         }
 
@@ -80,7 +81,7 @@ public struct BenchmarkRunner {
     func predictNumberOfIterationsNeeded(_ measurements: [Double], settings: BenchmarkSettings)
         -> Int
     {
-        let minTime = settings.minTime
+        let minTime = settings.minTime!
         let iters = measurements.count
 
         // See how much iterations should be increased by.
@@ -103,16 +104,16 @@ public struct BenchmarkRunner {
         let maxNextIters: Int = Int(max(multiplier * Double(iters), Double(iters) + 1.0).rounded())
 
         // But we do have *some* sanity limits though..
-        let nextIters = min(maxNextIters, settings.maxIterations)
+        let nextIters = min(maxNextIters, settings.maxIterations!)
 
         return nextIters
     }
 
     /// Heuristic when to stop looking for new number of iterations, ported from google/benchmark.
     func hasCollectedEnoughData(_ measurements: [Double], settings: BenchmarkSettings) -> Bool {
-        let tooManyIterations = measurements.count >= settings.maxIterations
+        let tooManyIterations = measurements.count >= settings.maxIterations!
         let timeInSeconds = measurements.reduce(0, +) / 1000000000.0
-        let timeIsLargeEnough = timeInSeconds >= settings.minTime
+        let timeIsLargeEnough = timeInSeconds >= settings.minTime!
         return tooManyIterations || timeIsLargeEnough
     }
 

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -81,7 +81,7 @@ public struct BenchmarkRunner {
     func predictNumberOfIterationsNeeded(_ measurements: [Double], settings: BenchmarkSettings)
         -> Int
     {
-        let minTime = settings.minTime!
+        let minTime = settings.minTime
         let iters = measurements.count
 
         // See how much iterations should be increased by.
@@ -104,16 +104,16 @@ public struct BenchmarkRunner {
         let maxNextIters: Int = Int(max(multiplier * Double(iters), Double(iters) + 1.0).rounded())
 
         // But we do have *some* sanity limits though..
-        let nextIters = min(maxNextIters, settings.maxIterations!)
+        let nextIters = min(maxNextIters, settings.maxIterations)
 
         return nextIters
     }
 
     /// Heuristic when to stop looking for new number of iterations, ported from google/benchmark.
     func hasCollectedEnoughData(_ measurements: [Double], settings: BenchmarkSettings) -> Bool {
-        let tooManyIterations = measurements.count >= settings.maxIterations!
+        let tooManyIterations = measurements.count >= settings.maxIterations
         let timeInSeconds = measurements.reduce(0, +) / 1000000000.0
-        let timeIsLargeEnough = timeInSeconds >= settings.minTime!
+        let timeIsLargeEnough = timeInSeconds >= settings.minTime
         return tooManyIterations || timeIsLargeEnough
     }
 

--- a/Sources/Benchmark/BenchmarkSetting.swift
+++ b/Sources/Benchmark/BenchmarkSetting.swift
@@ -12,8 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// A marker protocol for types that are intended to be
+/// be used as benchmark settings.
 public protocol BenchmarkSetting {}
 
+/// Static number of iterations to run the benchmark.
+/// If this setting is missing number of iterations will
+/// be computed empirically by running the benchmark.
 public struct Iterations: BenchmarkSetting {
     public var value: Int
     public init(_ value: Int) {
@@ -21,6 +26,8 @@ public struct Iterations: BenchmarkSetting {
     }
 }
 
+/// Maximum number of iterations to run, while emperically
+/// detecting number of iterations. 
 public struct MaxIterations: BenchmarkSetting {
     public var value: Int
     public init(_ value: Int) {
@@ -28,6 +35,8 @@ public struct MaxIterations: BenchmarkSetting {
     }
 }
 
+/// A guaranteed number of iterations to run an discard 
+/// as warmup time. 
 public struct WarmupIterations: BenchmarkSetting {
     public var value: Int
     public init(_ value: Int) {
@@ -35,6 +44,7 @@ public struct WarmupIterations: BenchmarkSetting {
     }
 }
 
+/// A regex string used to filter benchmarks that should be run.
 public struct Filter: BenchmarkSetting {
     public var value: String
     public init(_ value: String) {
@@ -42,6 +52,8 @@ public struct Filter: BenchmarkSetting {
     }
 }
 
+/// A minimal (total) time that iterations has to run
+/// to be considered significant.
 public struct MinTime: BenchmarkSetting {
     public var value: Double
     public init(seconds value: Double) {
@@ -49,6 +61,12 @@ public struct MinTime: BenchmarkSetting {
     }
 }
 
+/// An aggregate of all benchmark settings, that deduplicates
+/// the settings based on their type. A setting which is defined
+/// multiple times, only retains its last set value.
+///
+/// Settings can be indexed by their corresponding type. Helper
+/// accessor methods are provided for the default set of settings.
 public struct BenchmarkSettings {
     let settings: [String: Any]
 
@@ -75,6 +93,8 @@ public struct BenchmarkSettings {
         self.settings = settings
     }
 
+    /// Access a setting of given type or return nil
+    /// if it's not present.
     public subscript<T>(type: T.Type) -> T? {
         get {
             let key = String(describing: type)
@@ -90,10 +110,12 @@ public struct BenchmarkSettings {
         }
     }
 
+    /// Convenience accessor for Iterations setting.
     public var iterations: Int? {
         return self[Iterations.self]?.value
     }
 
+    /// Convenience accessor for MaxIterations setting.
     public var maxIterations: Int {
         if let value = self[MaxIterations.self]?.value {
             return value
@@ -102,14 +124,17 @@ public struct BenchmarkSettings {
         }
     }
 
+    /// Convenience accessor for WarmupIterations setting.
     public var warmupIterations: Int? {
         return self[WarmupIterations.self]?.value
     }
 
+    /// Convenience accessor for the Filter setting.
     public var filter: String? {
         return self[Filter.self]?.value
     }
 
+    /// Convenience accessor for the MinTime setting.
     public var minTime: Double {
         if let value = self[MinTime.self]?.value {
             return value

--- a/Sources/Benchmark/BenchmarkSetting.swift
+++ b/Sources/Benchmark/BenchmarkSetting.swift
@@ -94,8 +94,12 @@ public struct BenchmarkSettings {
         return self[Iterations.self]?.value
     }
 
-    public var maxIterations: Int? {
-        return self[MaxIterations.self]?.value
+    public var maxIterations: Int {
+        if let value = self[MaxIterations.self]?.value {
+            return value
+        } else {
+            fatalError("maxIterations must have a default.")
+        }
     }
 
     public var warmupIterations: Int? {
@@ -106,8 +110,12 @@ public struct BenchmarkSettings {
         return self[Filter.self]?.value
     }
 
-    public var minTime: Double? {
-        return self[MinTime.self]?.value
+    public var minTime: Double {
+        if let value = self[MinTime.self]?.value {
+            return value
+        } else {
+            fatalError("minTime must have a default.")
+        }
     }
 }
 

--- a/Sources/Benchmark/CMakeLists.txt
+++ b/Sources/Benchmark/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(Benchmark
   Benchmark.swift
+  BenchmarkArguments.swift
   BenchmarkClock.swift
   BenchmarkCommand.swift
   BenchmarkFilter.swift

--- a/Sources/BenchmarkSuiteExample/AddStringBenchmarks.swift
+++ b/Sources/BenchmarkSuiteExample/AddStringBenchmarks.swift
@@ -14,7 +14,7 @@
 
 import Benchmark
 
-public let addStringBenchmarks = BenchmarkSuite(name: "add string", settings: .iterations(10000)) {
+public let addStringBenchmarks = BenchmarkSuite(name: "add string", settings: Iterations(10000)) {
     suite in
     suite.benchmark("no capacity") {
         var x1: String = ""
@@ -23,7 +23,7 @@ public let addStringBenchmarks = BenchmarkSuite(name: "add string", settings: .i
         }
     }
 
-    suite.benchmark("reserved capacity", settings: .iterations(10001)) {
+    suite.benchmark("reserved capacity", settings: Iterations(10001)) {
         var x2: String = ""
         x2.reserveCapacity(2000)
         for _ in 1...1000 {

--- a/Tests/BenchmarkTests/BenchmarkCommandTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkCommandTests.swift
@@ -42,14 +42,16 @@ final class BenchmarkCommandTests: XCTestCase {
 
     func testParseFilter() throws {
         AssertParse(["--filter", "bar", "--allow-debug-build"]) { settings in
-            XCTAssertFalse(settings.filter.matches(suiteName: "foo", benchmarkName: "baz"))
-            XCTAssert(settings.filter.matches(suiteName: "foo", benchmarkName: "bar"))
+            let filter = try! BenchmarkFilter(settings.filter)
+            XCTAssertFalse(filter.matches(suiteName: "foo", benchmarkName: "baz"))
+            XCTAssert(filter.matches(suiteName: "foo", benchmarkName: "bar"))
         }
 
         AssertParse(["--filter", "foo/bar", "--allow-debug-build"]) { settings in
-            XCTAssertFalse(settings.filter.matches(suiteName: "foo", benchmarkName: "baz"))
-            XCTAssertFalse(settings.filter.matches(suiteName: "foobar", benchmarkName: "baz"))
-            XCTAssert(settings.filter.matches(suiteName: "foo", benchmarkName: "bar"))
+            let filter = try! BenchmarkFilter(settings.filter)
+            XCTAssertFalse(filter.matches(suiteName: "foo", benchmarkName: "baz"))
+            XCTAssertFalse(filter.matches(suiteName: "foobar", benchmarkName: "baz"))
+            XCTAssert(filter.matches(suiteName: "foo", benchmarkName: "bar"))
         }
     }
 
@@ -128,7 +130,7 @@ extension BenchmarkCommandTests {
         let settings: BenchmarkSettings
         do {
             parsed = try BenchmarkCommand.parse(arguments)
-            settings = try BenchmarkSettings(parsed.settings)
+            settings = BenchmarkSettings(parsed.arguments.settings)
         } catch {
             let message = BenchmarkCommand.message(for: error)
             XCTFail("\"\(message)\" - \(error)", file: file, line: line)

--- a/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
@@ -18,17 +18,17 @@ import XCTest
 
 final class BenchmarkRunnerTests: XCTestCase {
     func testFilterBenchmarksSuffix() throws {
-        let settings: [BenchmarkSetting] = [.iterations(1), .filter("b1")]
+        let settings: [BenchmarkSetting] = [Iterations(1), Filter("b1")]
         XCTAssertEqual(Set(["suite1/b1", "suite2/b1"]), runBenchmarks(settings: settings))
     }
 
     func testFilterBenchmarksSuiteName() throws {
-        let settings: [BenchmarkSetting] = [.iterations(1), .filter("suite1")]
+        let settings: [BenchmarkSetting] = [Iterations(1), Filter("suite1")]
         XCTAssertEqual(Set(["suite1/b1", "suite1/b2"]), runBenchmarks(settings: settings))
     }
 
     func testFilterBenchmarksFullName() throws {
-        let settings: [BenchmarkSetting] = [.iterations(1), .filter("suite1/b1")]
+        let settings: [BenchmarkSetting] = [Iterations(1), Filter("suite1/b1")]
         XCTAssertEqual(Set(["suite1/b1"]), runBenchmarks(settings: settings))
     }
 

--- a/Tests/BenchmarkTests/BenchmarkSettingTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkSettingTests.swift
@@ -21,7 +21,7 @@ final class BenchmarkSettingTests: XCTestCase {
     func assertNumberOfIterations(
         suite: BenchmarkSuite,
         counts expected: [Int],
-        cli settings: [BenchmarkSetting] = [.iterations(100000)]
+        cli settings: [BenchmarkSetting] = [Iterations(100000)]
     ) throws {
         var runner = BenchmarkRunner(
             suites: [suite], settings: settings, reporter: BlackHoleReporter())
@@ -44,7 +44,7 @@ final class BenchmarkSettingTests: XCTestCase {
     }
 
     func testSuiteSetting() throws {
-        let suite = BenchmarkSuite(name: "Test", settings: .iterations(42)) { suite in
+        let suite = BenchmarkSuite(name: "Test", settings: Iterations(42)) { suite in
             suite.benchmark("a") {}
             suite.benchmark("b") {}
         }
@@ -54,21 +54,21 @@ final class BenchmarkSettingTests: XCTestCase {
     func testBenchmarkSetting() throws {
         let suite = BenchmarkSuite(name: "Test") { suite in
             suite.benchmark("a") {}
-            suite.benchmark("b", settings: .iterations(42)) {}
+            suite.benchmark("b", settings: Iterations(42)) {}
         }
         try assertNumberOfIterations(suite: suite, counts: [100000, 42])
     }
 
     func testBenchmarkSettingOverridesSuiteSetting() throws {
-        let suite = BenchmarkSuite(name: "Test", settings: .iterations(42)) { suite in
+        let suite = BenchmarkSuite(name: "Test", settings: Iterations(42)) { suite in
             suite.benchmark("a") {}
-            suite.benchmark("b", settings: .iterations(21)) {}
+            suite.benchmark("b", settings: Iterations(21)) {}
         }
         try assertNumberOfIterations(suite: suite, counts: [42, 21])
     }
 
     func testCliSetting() throws {
-        let cli: [BenchmarkSetting] = [.iterations(1)]
+        let cli: [BenchmarkSetting] = [Iterations(1)]
         let suite = BenchmarkSuite(name: "Test") { suite in
             suite.benchmark("a") {}
             suite.benchmark("b") {}
@@ -77,8 +77,8 @@ final class BenchmarkSettingTests: XCTestCase {
     }
 
     func testSuiteOverridesCliSetting() throws {
-        let cli: [BenchmarkSetting] = [.iterations(1)]
-        let suite = BenchmarkSuite(name: "Test", settings: .iterations(2)) { suite in
+        let cli: [BenchmarkSetting] = [Iterations(1)]
+        let suite = BenchmarkSuite(name: "Test", settings: Iterations(2)) { suite in
             suite.benchmark("a") {}
             suite.benchmark("b") {}
         }
@@ -86,19 +86,19 @@ final class BenchmarkSettingTests: XCTestCase {
     }
 
     func testBenchmarkOverridesCliSetting() throws {
-        let cli: [BenchmarkSetting] = [.iterations(1)]
+        let cli: [BenchmarkSetting] = [Iterations(1)]
         let suite = BenchmarkSuite(name: "Test") { suite in
             suite.benchmark("a") {}
-            suite.benchmark("b", settings: .iterations(2)) {}
+            suite.benchmark("b", settings: Iterations(2)) {}
         }
         try assertNumberOfIterations(suite: suite, counts: [1, 2], cli: cli)
     }
 
     func testBenchmarkAndSuiteOverridesCliSetting() throws {
-        let cli: [BenchmarkSetting] = [.iterations(1)]
-        let suite = BenchmarkSuite(name: "Test", settings: .iterations(2)) { suite in
+        let cli: [BenchmarkSetting] = [Iterations(1)]
+        let suite = BenchmarkSuite(name: "Test", settings: Iterations(2)) { suite in
             suite.benchmark("a") {}
-            suite.benchmark("b", settings: .iterations(3)) {}
+            suite.benchmark("b", settings: Iterations(3)) {}
         }
         try assertNumberOfIterations(suite: suite, counts: [2, 3], cli: cli)
     }


### PR DESCRIPTION
This change makes settings an open set via a `BenchmarkSetting` protocol, replacing the previous enum-based `BenchmarkSetting` which could not be amended by the users.

In addition, command-line arguments are factored out into their own arguments bundle called `BenchmarkArguments`. The bundle can be easily reused to define custom CLI commands that also include benchmark arguments (without having to redefine them).

To add new setting(s), `swift-benchmark` user needs to:

1) Define a new struct(s) for the setting that conforms to `BenchmarkSetting`.
2) Define a custom `ParseableCommand` that includes `BenchmarkArguments`, and add any extra arguments in there.
3) Define a helper that converts command arguments into `BenchmarkSetting`-s, similar to the one defined in `BenchmarkArguments`. 
4) Use a new main overload that accepts a sequence of settings, and allows to use custom command parser beforehand. 
5) (optional) define helpers that simplify access on `BenchmarkSettings` container, similarly to the one provided for the default settings.