### PR TITLE
Add warmup column

### DIFF
--- a/Sources/Benchmark/BenchmarkResult.swift
+++ b/Sources/Benchmark/BenchmarkResult.swift
@@ -16,14 +16,17 @@ public struct BenchmarkResult {
     public let benchmarkName: String
     public let suiteName: String
     public let measurements: [Double]
+    public let warmupMeasurements: [Double]
     public let counters: [String: Double]
 
     public init(
-        benchmarkName: String, suiteName: String, measurements: [Double], counters: [String: Double]
+        benchmarkName: String, suiteName: String, measurements: [Double],
+        warmupMeasurements: [Double], counters: [String: Double]
     ) {
         self.benchmarkName = benchmarkName
         self.suiteName = suiteName
         self.measurements = measurements
+        self.warmupMeasurements = warmupMeasurements
         self.counters = counters
     }
 }

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -53,8 +53,9 @@ public struct BenchmarkRunner {
         reporter.report(running: benchmark.name, suite: suite.name)
         let totalStart = now()
 
+        var warmupState: BenchmarkState? = nil
         if let n = settings.warmupIterations {
-            let _ = doNIterations(n, benchmark: benchmark, suite: suite, settings: settings)
+            warmupState = doNIterations(n, benchmark: benchmark, suite: suite, settings: settings)
         }
 
         var state: BenchmarkState
@@ -75,6 +76,7 @@ public struct BenchmarkRunner {
             benchmarkName: benchmark.name,
             suiteName: suite.name,
             measurements: state.measurements,
+            warmupMeasurements: warmupState != nil ? warmupState!.measurements : [],
             counters: state.counters)
         results.append(result)
     }

--- a/Tests/BenchmarkTests/BenchmarkReporterTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkReporterTests.swift
@@ -34,10 +34,14 @@ final class BenchmarkReporterTests: XCTestCase {
     func testPlainTextReporter() throws {
         let results: [BenchmarkResult] = [
             BenchmarkResult(
-                benchmarkName: "fast", suiteName: "My Suite", measurements: [1_000, 2_000],
+                benchmarkName: "fast", suiteName: "My Suite",
+                measurements: [1_000, 2_000],
+                warmupMeasurements: [],
                 counters: [:]),
             BenchmarkResult(
-                benchmarkName: "slow", suiteName: "My Suite", measurements: [1_000_000, 2_000_000],
+                benchmarkName: "slow", suiteName: "My Suite",
+                measurements: [1_000_000, 2_000_000],
+                warmupMeasurements: [],
                 counters: [:]),
         ]
         let expected = #"""
@@ -47,16 +51,17 @@ final class BenchmarkReporterTests: XCTestCase {
             My Suite: slow 1500000.0 ns ±  47.14 %          2
             """#
         assertIsPrintedAs(results, expected)
-
     }
 
     func testCountersAreReported() throws {
         let results: [BenchmarkResult] = [
             BenchmarkResult(
                 benchmarkName: "fast", suiteName: "My Suite", measurements: [1_000, 2_000],
+                warmupMeasurements: [],
                 counters: ["n": 7]),
             BenchmarkResult(
                 benchmarkName: "slow", suiteName: "My Suite", measurements: [1_000_000, 2_000_000],
+                warmupMeasurements: [],
                 counters: [:]),
         ]
         let expected = #"""
@@ -66,11 +71,31 @@ final class BenchmarkReporterTests: XCTestCase {
             My Suite: slow 1500000.0 ns ±  47.14 %          2
             """#
         assertIsPrintedAs(results, expected)
+    }
+
+    func testWarmupReported() throws {
+        let results: [BenchmarkResult] = [
+            BenchmarkResult(
+                benchmarkName: "fast", suiteName: "My Suite", measurements: [1_000, 2_000],
+                warmupMeasurements: [10, 20, 30],
+                counters: [:]),
+            BenchmarkResult(
+                benchmarkName: "slow", suiteName: "My Suite", measurements: [1_000_000, 2_000_000],
+                warmupMeasurements: [],
+                counters: [:]),
+        ]
+        let expected = #"""
+            name           time         std        iterations warmup
+            ---------------------------------------------------------
+            My Suite: fast    1500.0 ns ±  47.14 %          2 60.0 ns
+            My Suite: slow 1500000.0 ns ±  47.14 %          2
+            """#
         assertIsPrintedAs(results, expected)
     }
 
     static var allTests = [
         ("testPlainTextReporter", testPlainTextReporter),
         ("testCountersAreReported", testCountersAreReported),
+        ("testWarmupReported", testWarmupReported),
     ]
 }

--- a/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
@@ -39,6 +39,21 @@ final class BenchmarkRunnerTests: XCTestCase {
             runBenchmarks(settings: settings))
     }
 
+    func testWarmupMeasurements() throws {
+        let suite = BenchmarkSuite(name: "Suite")
+
+        suite.benchmark("no warmup") {
+        }
+        suite.benchmark("needs warmup", settings: WarmupIterations(10)) {
+        }
+
+        let results = try run(suites: [suite], settings: [Iterations(100)])
+        XCTAssertEqual(results.count, 2)
+
+        let counts = results.map { $0.warmupMeasurements.count }
+        XCTAssertEqual(counts, [0, 10])
+    }
+
     func testCustomMeasurements() throws {
         let suite = BenchmarkSuite(name: "Suite")
 
@@ -101,6 +116,7 @@ final class BenchmarkRunnerTests: XCTestCase {
         ("testFilterBenchmarksSuiteName", testFilterBenchmarksSuiteName),
         ("testFilterBenchmarksFullName", testFilterBenchmarksFullName),
         ("testAutomaticallyDetectIterations", testAutomaticallyDetectIterations),
+        ("testWarmupMeasurements", testWarmupMeasurements),
         ("testCustomMeasurements", testCustomMeasurements),
         ("testCustomCounters", testCustomCounters),
     ]


### PR DESCRIPTION
This change introduces a new column that shows total time taken in warmup iterations. 

Currently it's always shown, but once #15 is fixed, we will be able to show it or not dynamically based on user preference. 