### PR TITLE
Add support for user-defined counters

### DIFF
--- a/Sources/Benchmark/BenchmarkResult.swift
+++ b/Sources/Benchmark/BenchmarkResult.swift
@@ -16,10 +16,14 @@ public struct BenchmarkResult {
     public let benchmarkName: String
     public let suiteName: String
     public let measurements: [Double]
+    public let counters: [String: Int]
 
-    public init(benchmarkName: String, suiteName: String, measurements: [Double]) {
+    public init(
+        benchmarkName: String, suiteName: String, measurements: [Double], counters: [String: Int]
+    ) {
         self.benchmarkName = benchmarkName
         self.suiteName = suiteName
         self.measurements = measurements
+        self.counters = counters
     }
 }

--- a/Sources/Benchmark/BenchmarkResult.swift
+++ b/Sources/Benchmark/BenchmarkResult.swift
@@ -16,10 +16,10 @@ public struct BenchmarkResult {
     public let benchmarkName: String
     public let suiteName: String
     public let measurements: [Double]
-    public let counters: [String: Int]
+    public let counters: [String: Double]
 
     public init(
-        benchmarkName: String, suiteName: String, measurements: [Double], counters: [String: Int]
+        benchmarkName: String, suiteName: String, measurements: [Double], counters: [String: Double]
     ) {
         self.benchmarkName = benchmarkName
         self.suiteName = suiteName

--- a/Sources/Benchmark/BenchmarkState.swift
+++ b/Sources/Benchmark/BenchmarkState.swift
@@ -26,7 +26,7 @@ public struct BenchmarkState {
     var measurements: [Double]
 
     /// A mapping from counters to their corresponding values.
-    public var counters: [String: Int]
+    public var counters: [String: Double]
 
     /// Aggregated settings for the current benchmark run. 
     public let settings: BenchmarkSettings
@@ -104,7 +104,7 @@ public struct BenchmarkState {
     /// If counter has never been set before, it starts with zero as the
     /// initial value.
     @inline(__always)
-    public mutating func increment(counter name: String, by value: Int = 1) {
+    public mutating func increment(counter name: String, by value: Double = 1) {
         if let oldValue = counters[name] {
             counters[name] = oldValue + value
         } else {

--- a/Tests/BenchmarkTests/BenchmarkReporterTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkReporterTests.swift
@@ -61,8 +61,8 @@ final class BenchmarkReporterTests: XCTestCase {
         ]
         let expected = #"""
             name           time         std        iterations n
-            ---------------------------------------------------
-            My Suite: fast    1500.0 ns ±  47.14 %          2 7
+            -----------------------------------------------------
+            My Suite: fast    1500.0 ns ±  47.14 %          2 7.0
             My Suite: slow 1500000.0 ns ±  47.14 %          2
             """#
         assertIsPrintedAs(results, expected)


### PR DESCRIPTION
This change introduces support for counters that be updated through either:

1) `state.counters["name"] = value`
2) `state.increment(counter: "name")`
3) `state.increment(counter: "name", by: value)`

Counters are useful to record domain-specific statistics apart from the time measurements.

Fixes #11