### PR TITLE
Add support for configurable time units

### DIFF
--- a/Sources/Benchmark/BenchmarkArguments.swift
+++ b/Sources/Benchmark/BenchmarkArguments.swift
@@ -36,6 +36,9 @@ public struct BenchmarkArguments: ParsableArguments {
         help: "Maximum number of iterations to run when automatically detecting number iterations.")
     var maxIterations: Int?
 
+    @Option(help: "Time unit used to report the results.")
+    var timeUnit: TimeUnit.Value?
+
     public init() {}
 
     /// Conversion from command-line arguments to benchmark settings.
@@ -56,6 +59,9 @@ public struct BenchmarkArguments: ParsableArguments {
         }
         if let value = maxIterations {
             result.append(MaxIterations(value))
+        }
+        if let value = timeUnit {
+            result.append(TimeUnit(value))
         }
 
         return result

--- a/Sources/Benchmark/BenchmarkReporter.swift
+++ b/Sources/Benchmark/BenchmarkReporter.swift
@@ -96,10 +96,11 @@ struct PlainTextReporter<Target>: BenchmarkReporter where Target: TextOutputStre
 
             let median = result.measurements.median
             let std = result.measurements.std
+            let timeUnit = result.settings.timeUnit
 
             var row: Row = [
                 .name: name,
-                .time: "\(median) ns",
+                .time: median.formatTime(timeUnit),
                 .std: "± \(String(format: "%6.2f %%", (std / median) * 100))",
                 .iterations: "\(result.measurements.count)",
             ]
@@ -169,5 +170,16 @@ extension String {
     fileprivate func rightPadding(toLength newLength: Int, withPad character: Character) -> String {
         precondition(count <= newLength, "newLength must be greater than or equal to string length")
         return self + String(repeating: character, count: newLength - count)
+    }
+}
+
+extension Double {
+    fileprivate func formatTime(_ unit: TimeUnit.Value) -> String {
+        switch unit {
+        case .ns: return "\(self) ns"
+        case .us: return "\(self/1000.0) us"
+        case .ms: return "\(self/100_000.0) ms"
+        case .s: return "\(self/1000_000_000.0) s"
+        }
     }
 }

--- a/Sources/Benchmark/BenchmarkResult.swift
+++ b/Sources/Benchmark/BenchmarkResult.swift
@@ -15,16 +15,19 @@
 public struct BenchmarkResult {
     public let benchmarkName: String
     public let suiteName: String
+    public let settings: BenchmarkSettings
     public let measurements: [Double]
     public let warmupMeasurements: [Double]
     public let counters: [String: Double]
 
     public init(
-        benchmarkName: String, suiteName: String, measurements: [Double],
+        benchmarkName: String, suiteName: String,
+        settings: BenchmarkSettings, measurements: [Double],
         warmupMeasurements: [Double], counters: [String: Double]
     ) {
         self.benchmarkName = benchmarkName
         self.suiteName = suiteName
+        self.settings = settings
         self.measurements = measurements
         self.warmupMeasurements = warmupMeasurements
         self.counters = counters

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -76,6 +76,7 @@ public struct BenchmarkRunner {
         let result = BenchmarkResult(
             benchmarkName: benchmark.name,
             suiteName: suite.name,
+            settings: settings,
             measurements: state.measurements,
             warmupMeasurements: warmupState != nil ? warmupState!.measurements : [],
             counters: state.counters)

--- a/Sources/Benchmark/BenchmarkSetting.swift
+++ b/Sources/Benchmark/BenchmarkSetting.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import ArgumentParser
+
 /// A marker protocol for types that are intended to be
 /// be used as benchmark settings.
 public protocol BenchmarkSetting {}
@@ -61,6 +63,20 @@ public struct MinTime: BenchmarkSetting {
     }
 }
 
+/// Time unit for reporting results.
+public struct TimeUnit: BenchmarkSetting {
+    public var value: Value
+    public init(_ value: Value) {
+        self.value = value
+    }
+    public enum Value: String, ExpressibleByArgument {
+        case ns
+        case us
+        case ms
+        case s
+    }
+}
+
 /// An aggregate of all benchmark settings, that deduplicates
 /// the settings based on their type. A setting which is defined
 /// multiple times, only retains its last set value.
@@ -86,7 +102,7 @@ public struct BenchmarkSettings {
     }
 
     public init() {
-        self.init([:])
+        self.init(defaultSettings)
     }
 
     init(_ settings: [String: BenchmarkSetting]) {
@@ -146,9 +162,19 @@ public struct BenchmarkSettings {
             fatalError("minTime must have a default.")
         }
     }
+
+    /// Convenience accessor for the TimeUnit setting. 
+    public var timeUnit: TimeUnit.Value {
+        if let value = self[TimeUnit.self]?.value {
+            return value
+        } else {
+            fatalError("timeUnit must have a default.")
+        }
+    }
 }
 
 let defaultSettings: [BenchmarkSetting] = [
     MaxIterations(1_000_000),
     MinTime(seconds: 1.0),
+    TimeUnit(.ns),
 ]

--- a/Tests/BenchmarkTests/BenchmarkReporterTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkReporterTests.swift
@@ -35,11 +35,13 @@ final class BenchmarkReporterTests: XCTestCase {
         let results: [BenchmarkResult] = [
             BenchmarkResult(
                 benchmarkName: "fast", suiteName: "My Suite",
+                settings: BenchmarkSettings(),
                 measurements: [1_000, 2_000],
                 warmupMeasurements: [],
                 counters: [:]),
             BenchmarkResult(
                 benchmarkName: "slow", suiteName: "My Suite",
+                settings: BenchmarkSettings(),
                 measurements: [1_000_000, 2_000_000],
                 warmupMeasurements: [],
                 counters: [:]),
@@ -56,11 +58,15 @@ final class BenchmarkReporterTests: XCTestCase {
     func testCountersAreReported() throws {
         let results: [BenchmarkResult] = [
             BenchmarkResult(
-                benchmarkName: "fast", suiteName: "My Suite", measurements: [1_000, 2_000],
+                benchmarkName: "fast", suiteName: "My Suite",
+                settings: BenchmarkSettings(),
+                measurements: [1_000, 2_000],
                 warmupMeasurements: [],
                 counters: ["n": 7]),
             BenchmarkResult(
-                benchmarkName: "slow", suiteName: "My Suite", measurements: [1_000_000, 2_000_000],
+                benchmarkName: "slow", suiteName: "My Suite",
+                settings: BenchmarkSettings(),
+                measurements: [1_000_000, 2_000_000],
                 warmupMeasurements: [],
                 counters: [:]),
         ]
@@ -76,11 +82,15 @@ final class BenchmarkReporterTests: XCTestCase {
     func testWarmupReported() throws {
         let results: [BenchmarkResult] = [
             BenchmarkResult(
-                benchmarkName: "fast", suiteName: "My Suite", measurements: [1_000, 2_000],
+                benchmarkName: "fast", suiteName: "My Suite",
+                settings: BenchmarkSettings(),
+                measurements: [1_000, 2_000],
                 warmupMeasurements: [10, 20, 30],
                 counters: [:]),
             BenchmarkResult(
-                benchmarkName: "slow", suiteName: "My Suite", measurements: [1_000_000, 2_000_000],
+                benchmarkName: "slow", suiteName: "My Suite",
+                settings: BenchmarkSettings(),
+                measurements: [1_000_000, 2_000_000],
                 warmupMeasurements: [],
                 counters: [:]),
         ]
@@ -93,9 +103,48 @@ final class BenchmarkReporterTests: XCTestCase {
         assertIsPrintedAs(results, expected)
     }
 
+    func testTimeUnitReported() throws {
+        let results: [BenchmarkResult] = [
+            BenchmarkResult(
+                benchmarkName: "ns", suiteName: "My Suite",
+                settings: BenchmarkSettings([TimeUnit(.ns)]),
+                measurements: [123_456_789],
+                warmupMeasurements: [],
+                counters: [:]),
+            BenchmarkResult(
+                benchmarkName: "us", suiteName: "My Suite",
+                settings: BenchmarkSettings([TimeUnit(.us)]),
+                measurements: [123_456_789],
+                warmupMeasurements: [],
+                counters: [:]),
+            BenchmarkResult(
+                benchmarkName: "ms", suiteName: "My Suite",
+                settings: BenchmarkSettings([TimeUnit(.ms)]),
+                measurements: [123_456_789],
+                warmupMeasurements: [],
+                counters: [:]),
+            BenchmarkResult(
+                benchmarkName: "s", suiteName: "My Suite",
+                settings: BenchmarkSettings([TimeUnit(.s)]),
+                measurements: [123_456_789],
+                warmupMeasurements: [],
+                counters: [:]),
+        ]
+        let expected = #"""
+            name         time           std        iterations
+            -------------------------------------------------
+            My Suite: ns 123456789.0 ns ±   0.00 %          1
+            My Suite: us  123456.789 us ±   0.00 %          1
+            My Suite: ms  1234.56789 ms ±   0.00 %          1
+            My Suite: s   0.123456789 s ±   0.00 %          1
+            """#
+        assertIsPrintedAs(results, expected)
+    }
+
     static var allTests = [
         ("testPlainTextReporter", testPlainTextReporter),
         ("testCountersAreReported", testCountersAreReported),
         ("testWarmupReported", testWarmupReported),
+        ("testTimeUnitReported", testTimeUnitReported),
     ]
 }


### PR DESCRIPTION
This change adds support for configuring `--time-unit` to be one of: `ns`, `us`, `ms`, `s`.

Fixes #26