### PR TITLE
 Make output columns customizable

### DIFF
--- a/Sources/Benchmark/BenchmarkArguments.swift
+++ b/Sources/Benchmark/BenchmarkArguments.swift
@@ -73,7 +73,8 @@ public struct BenchmarkArguments: ParsableArguments {
             result.append(InverseTimeUnit(value))
         }
         if let value = columns {
-            result.append(try! Columns(value))
+            let names = value.split(separator: ",").map { String($0) }
+            result.append(Columns(Array(names)))
         }
 
         return result
@@ -106,7 +107,11 @@ public struct BenchmarkArguments: ParsableArguments {
                 positiveNumberError(flag: "--min-time", of: "floating point number"))
         }
         if let value = columns {
-            let _ = try Columns(value)
+            for name in value.split(separator: ",") {
+                if BenchmarkColumn.registry[String(name)] == nil {
+                    throw ValidationError("Unknown output column: `\(name)`.")
+                }
+            }
         }
     }
 

--- a/Sources/Benchmark/BenchmarkArguments.swift
+++ b/Sources/Benchmark/BenchmarkArguments.swift
@@ -36,10 +36,10 @@ public struct BenchmarkArguments: ParsableArguments {
         help: "Maximum number of iterations to run when automatically detecting number iterations.")
     var maxIterations: Int?
 
-    @Option(help: "Time unit used to report the results.")
+    @Option(help: "Time unit used to report the timing results.")
     var timeUnit: TimeUnit.Value?
 
-    @Option(help: "Time unit used to report the results.")
+    @Option(help: "Inverse time unit used to report throughput results.")
     var inverseTimeUnit: TimeUnit.Value?
 
     @Option(help: "List of columns to show.")

--- a/Sources/Benchmark/BenchmarkArguments.swift
+++ b/Sources/Benchmark/BenchmarkArguments.swift
@@ -42,7 +42,7 @@ public struct BenchmarkArguments: ParsableArguments {
     @Option(help: "Inverse time unit used to report throughput results.")
     var inverseTimeUnit: TimeUnit.Value?
 
-    @Option(help: "List of columns to show.")
+    @Option(help: "Comma-separated list of column names to show.")
     var columns: String?
 
     public init() {}

--- a/Sources/Benchmark/BenchmarkArguments.swift
+++ b/Sources/Benchmark/BenchmarkArguments.swift
@@ -39,6 +39,12 @@ public struct BenchmarkArguments: ParsableArguments {
     @Option(help: "Time unit used to report the results.")
     var timeUnit: TimeUnit.Value?
 
+    @Option(help: "Time unit used to report the results.")
+    var inverseTimeUnit: TimeUnit.Value?
+
+    @Option(help: "List of columns to show.")
+    var columns: String?
+
     public init() {}
 
     /// Conversion from command-line arguments to benchmark settings.
@@ -62,6 +68,12 @@ public struct BenchmarkArguments: ParsableArguments {
         }
         if let value = timeUnit {
             result.append(TimeUnit(value))
+        }
+        if let value = inverseTimeUnit {
+            result.append(InverseTimeUnit(value))
+        }
+        if let value = columns {
+            result.append(try! Columns(value))
         }
 
         return result
@@ -92,6 +104,9 @@ public struct BenchmarkArguments: ParsableArguments {
         if minTime != nil && minTime! <= 0 {
             throw ValidationError(
                 positiveNumberError(flag: "--min-time", of: "floating point number"))
+        }
+        if let value = columns {
+            let _ = try Columns(value)
         }
     }
 

--- a/Sources/Benchmark/BenchmarkColumn.swift
+++ b/Sources/Benchmark/BenchmarkColumn.swift
@@ -15,11 +15,122 @@
 public struct BenchmarkColumn: Hashable {
     typealias Column = BenchmarkColumn
     typealias Row = [Column: String]
-    typealias Content = (BenchmarkResult, Bool) -> String
 
-    let name: String
-    let content: Content
-    let alignment: Alignment
+    public let name: String
+    public let content: (BenchmarkResult) -> Content
+    public let alignment: Alignment
+
+    public enum Content {
+        case string(String)
+        case time(Double)
+        case inverseTime(Double)
+        case percentage(Double)
+        case number(Double)
+    }
+
+    public enum Alignment: Hashable {
+        case left
+        case right
+    }
+
+    public init(
+        name: String,
+        content: @escaping (BenchmarkResult) -> Content,
+        alignment: Alignment
+    ) {
+        self.name = name
+        self.content = content
+        self.alignment = alignment
+    }
+
+    public static var registry: [String: BenchmarkColumn] = {
+        var result: [String: BenchmarkColumn] = [:]
+
+        // Default columns.
+        result["name"] = BenchmarkColumn(
+            name: "name",
+            content: { result in
+                if result.suiteName != "" {
+                    return .string("\(result.suiteName).\(result.benchmarkName)")
+                } else {
+                    return .string(result.benchmarkName)
+                }
+            },
+            alignment: .left)
+        result["time"] = BenchmarkColumn(
+            name: "time",
+            content: { .time($0.measurements.median) },
+            alignment: .right)
+        result["std"] = BenchmarkColumn(
+            name: "std",
+            content: { .percentage($0.measurements.std / $0.measurements.median * 100) },
+            alignment: .left)
+        result["iterations"] = BenchmarkColumn(
+            name: "iterations",
+            content: { .number(Double($0.measurements.count)) },
+            alignment: .right)
+        result["warmup"] = BenchmarkColumn(
+            name: "warmup",
+            content: { .time($0.warmupMeasurements.sum) },
+            alignment: .right)
+
+        // Opt-in alternative columns.
+        result["median"] = BenchmarkColumn(
+            name: "median",
+            content: { .time($0.measurements.median) },
+            alignment: .right)
+        result["min"] = BenchmarkColumn(
+            name: "min",
+            content: { result in
+                if let value = result.measurements.min() {
+                    return .time(value)
+                } else {
+                    return .time(0)
+                }
+            },
+            alignment: .right)
+        result["max"] = BenchmarkColumn(
+            name: "max",
+            content: { result in
+                if let value = result.measurements.max() {
+                    return .time(value)
+                } else {
+                    return .time(0)
+                }
+            },
+            alignment: .right)
+        result["total"] = BenchmarkColumn(
+            name: "total",
+            content: { .time($0.measurements.sum) },
+            alignment: .right)
+        result["avg"] = BenchmarkColumn(
+            name: "avg",
+            content: { .time($0.measurements.average) },
+            alignment: .right)
+        result["average"] = BenchmarkColumn(
+            name: "avg",
+            content: { .time($0.measurements.average) },
+            alignment: .right)
+        result["std_abs"] = BenchmarkColumn(
+            name: "std_abs",
+            content: { .number($0.measurements.std) },
+            alignment: .left)
+        var percentiles: [Double] = []
+        percentiles.append(contentsOf: (0...100).map { Double($0) })
+        percentiles.append(contentsOf: [99.9, 99.99, 99.999, 99.9999])
+        for v in percentiles {
+            var name = "p\(v)"
+            if name.hasSuffix(".0") {
+                name = String(name.dropLast(2))
+            }
+            result[name] = BenchmarkColumn(
+                name: name,
+                content: { .time($0.measurements.percentile(v)) },
+                alignment: .left)
+        }
+
+        return result
+    }()
 
     public static func == (lhs: Self, rhs: Self) -> Bool {
         return lhs.name == rhs.name
@@ -29,145 +140,40 @@ public struct BenchmarkColumn: Hashable {
         name.hash(into: &hasher)
     }
 
-    init(name: String, content: @escaping Content, alignment: Alignment) {
-        self.name = name
-        self.content = content
-        self.alignment = alignment
-    }
-
     static func defaults(results: [BenchmarkResult]) -> [Column] {
-        func custom(_ custom: CustomContent) -> Content {
-            return custom.content()
-        }
-
-        var columns = [
-            // name=:.name
-            Column(
-                name: "name",
-                content: custom(.name),
-                alignment: .left),
-            // time=time.median:
-            Column(
-                name: "time",
-                content: custom(.value(.median(.time))),
-                alignment: .right),
-            // std=:time.std.divide.time.median
-            Column(
-                name: "std",
-                content: custom(.value(.percentage(.divide(.std(.time), .median(.time))))),
-                alignment: .left),
-            // iterations=iterations:
-            Column(
-                name: "iterations",
-                content: custom(.value(.iterations)),
-                alignment: .right),
-        ]
-        var counters: Set<String> = Set()
         var showWarmup: Bool = false
+        var counters: Set<String> = Set()
         for result in results {
             showWarmup = showWarmup || result.warmupMeasurements.count > 0
             for counter in result.counters.keys {
                 counters.insert(counter)
             }
         }
-        for counter in Array(counters).sorted() {
-            // counter_name=counter.counter_name:
-            columns.append(
-                Column(
-                    name: counter,
-                    content: custom(.value(.counter(counter))),
-                    alignment: .right))
-        }
+
+        var columns = [
+            BenchmarkColumn.registry["name"]!,
+            BenchmarkColumn.registry["time"]!,
+            BenchmarkColumn.registry["std"]!,
+            BenchmarkColumn.registry["iterations"]!,
+        ]
         if showWarmup {
-            // warmup=warmupTime.sum:
+            columns.append(BenchmarkColumn.registry["warmup"]!)
+        }
+        for counter in Array(counters).sorted() {
             columns.append(
-                Column(
-                    name: "warmup",
-                    content: custom(.value(.sum(.warmupTime))),
+                BenchmarkColumn(
+                    name: counter,
+                    content: { result in
+                        if let value = result.counters[counter] {
+                            return .number(value)
+                        } else {
+                            return .number(0)
+                        }
+                    },
                     alignment: .right))
         }
+
         return columns
-    }
-
-    enum CustomContent: Hashable {
-        case name
-        case value(Value)
-
-        func content() -> Content {
-            return { (result, pretty) in
-                switch self {
-                case .name:
-                    if result.suiteName != "" {
-                        return "\(result.suiteName).\(result.benchmarkName)"
-                    } else {
-                        return result.benchmarkName
-                    }
-                case .value(let value):
-                    let evaluated = evaluate(value: value, result: result)
-                    if !pretty {
-                        return String(evaluated)
-                    }
-                    let suffix: String = containsStd(value) ? "± " : ""
-                    switch unit(value) {
-                    case .percentage:
-                        return suffix + String(format: "%6.2f %%", evaluated)
-                    case .time:
-                        switch result.settings.timeUnit {
-                        case .ns: return suffix + "\(evaluated) ns"
-                        case .us: return suffix + "\(evaluated/1000.0) us"
-                        case .ms: return suffix + "\(evaluated/1000_000.0) ms"
-                        case .s: return suffix + "\(evaluated/1000_000_000.0) s"
-                        }
-                    case .inverseTime:
-                        switch result.settings.inverseTimeUnit {
-                        case .ns: return suffix + "\(evaluated) /ns"
-                        case .us: return suffix + "\(evaluated*1000.0) /us"
-                        case .ms: return suffix + "\(evaluated*1000_000.0) /ms"
-                        case .s: return suffix + "\(evaluated*1000_000_000.0) /s"
-                        }
-                    case .none:
-                        let string = String(evaluated)
-                        if string.hasSuffix(".0") {
-                            return suffix + String(string.dropLast(2))
-                        } else {
-                            return suffix + string
-                        }
-                    }
-                }
-            }
-        }
-
-    }
-
-    enum Alignment: Hashable {
-        case left
-        case right
-    }
-
-    indirect enum Base: Hashable {
-        case time
-        case warmupTime
-    }
-
-    indirect enum Value: Hashable {
-        case median(Base)
-        case std(Base)
-        case min(Base)
-        case max(Base)
-        case sum(Base)
-        case average(Base)
-        case percentile(Double, Base)
-        case counter(String)
-        case iterations
-        case divide(Value, Value)
-        case percentage(Value)
-    }
-
-    enum Unit {
-        case none
-        case percentage
-        case time
-        case inverseTime
     }
 
     static func evaluate(columns: [Column], results: [BenchmarkResult], pretty: Bool) -> [Row] {
@@ -180,287 +186,57 @@ public struct BenchmarkColumn: Hashable {
         for result in results {
             var row: Row = [:]
             for column in columns {
-                row[column] = column.content(result, pretty)
+                var content: String
+                if !pretty {
+                    switch column.content(result) {
+                    case .string(let value):
+                        content = value
+                    case .time(let value):
+                        content = String(value)
+                    case .inverseTime(let value):
+                        content = String(value)
+                    case .percentage(let value):
+                        content = String(value)
+                    case .number(let value):
+                        content = String(value)
+                    }
+                } else {
+                    switch column.content(result) {
+                    case .string(let value):
+                        content = value
+                    case .time(let value):
+                        switch result.settings.timeUnit {
+                        case .ns: content = "\(value) ns"
+                        case .us: content = "\(value/1000.0) us"
+                        case .ms: content = "\(value/1000_000.0) ms"
+                        case .s: content = "\(value/1000_000_000.0) s"
+                        }
+                    case .inverseTime(let value):
+                        switch result.settings.inverseTimeUnit {
+                        case .ns: content = "\(value) /ns"
+                        case .us: content = "\(value*1000.0) /us"
+                        case .ms: content = "\(value*1000_000.0) /ms"
+                        case .s: content = "\(value*1000_000_000.0) /s"
+                        }
+                    case .percentage(let value):
+                        content = String(format: "%6.2f %%", value)
+                    case .number(let value):
+                        let string = String(value)
+                        if string.hasSuffix(".0") {
+                            content = String(string.dropLast(2))
+                        } else {
+                            content = string
+                        }
+                    }
+                    if column.name == "std" || column.name == "std_abs" {
+                        content = "± " + content
+                    }
+                }
+                row[column] = content
             }
             rows.append(row)
         }
 
         return rows
-    }
-
-    static func containsStd(_ value: Value) -> Bool {
-        switch value {
-        case .std(_):
-            return true
-        case .median(_), .min(_), .max(_), .sum(_), .average(_), .counter(_), .iterations,
-            .percentile(_, _):
-            return false
-        case .divide(let lhs, let rhs):
-            return containsStd(lhs) || containsStd(rhs)
-        case .percentage(let arg):
-            return containsStd(arg)
-        }
-    }
-
-    static func unit(_ value: Value) -> Unit {
-        switch value {
-        case .median(_), .std(_), .min(_), .max(_), .sum(_), .average(_), .percentile(_, _):
-            return .time
-        case .counter(_), .iterations:
-            return .none
-        case .divide(let lhs, let rhs):
-            switch (unit(lhs), unit(rhs)) {
-            case (.none, .time):
-                return .inverseTime
-            default:
-                return .none
-            }
-        case .percentage(_):
-            return .percentage
-        }
-    }
-
-    static func evaluate(base: Base, result: BenchmarkResult) -> [Double] {
-        switch base {
-        case .time:
-            return result.measurements
-        case .warmupTime:
-            return result.warmupMeasurements
-        }
-    }
-
-    static func evaluate(value: Value, result: BenchmarkResult) -> Double {
-        switch value {
-        case .median(let arg):
-            let base = evaluate(base: arg, result: result)
-            return base.median
-        case .std(let arg):
-            let base = evaluate(base: arg, result: result)
-            return base.std
-        case .min(let arg):
-            let base = evaluate(base: arg, result: result)
-            if let value = base.min() {
-                return value
-            } else {
-                return 0
-            }
-        case .max(let arg):
-            let base = evaluate(base: arg, result: result)
-            if let value = base.max() {
-                return value
-            } else {
-                return 0
-            }
-        case .sum(let arg):
-            let base = evaluate(base: arg, result: result)
-            return base.sum
-        case .average(let arg):
-            let base = evaluate(base: arg, result: result)
-            if base.count == 0 {
-                return 0
-            } else {
-                return base.average
-            }
-        case .percentile(let p, let arg):
-            let base = evaluate(base: arg, result: result)
-            if base.count == 0 {
-                return 0
-            } else {
-                return base.percentile(p)
-            }
-        case .counter(let counter):
-            if let value = result.counters[counter] {
-                return value
-            } else {
-                return 0
-            }
-        case .divide(let lhs, let rhs):
-            return evaluate(value: lhs, result: result) / evaluate(value: rhs, result: result)
-        case .percentage(let arg):
-            return evaluate(value: arg, result: result) * 100.0
-        case .iterations:
-            return Double(result.measurements.count)
-        }
-    }
-
-    static func parse(columns: String) throws -> [Column] {
-        if columns.contains(",") {
-            var result: [Column] = []
-            for column in columns.split(separator: ",") {
-                result.append(try parse(column: String(column)))
-            }
-            return result
-        } else {
-            return [try parse(column: columns)]
-        }
-    }
-
-    static func parse(column: String) throws -> Column {
-        var columnName = ""
-        var alignment: Alignment = .left
-        var rest = column
-
-        if rest.contains("=") {
-            let nameParts = rest.split(separator: "=", maxSplits: 2)
-            columnName = String(nameParts[0])
-            rest = String(nameParts[1])
-        }
-        if rest.first == ":" {
-            alignment = .left
-            rest = String(rest.dropFirst())
-        }
-        if rest.last == ":" {
-            alignment = .right
-            rest = String(rest.dropLast())
-        }
-
-        let customContent = try parse(customContent: rest)
-        if columnName == "" {
-            columnName = name(customContent: customContent)
-        }
-        let content = customContent.content()
-
-        return Column(name: columnName, content: content, alignment: alignment)
-    }
-
-    static func parse(customContent: String) throws -> CustomContent {
-        if customContent == "name" {
-            return .name
-        } else {
-            return .value(try parse(value: customContent))
-        }
-    }
-
-    static func parse(value: String) throws -> Value {
-        try parse(value: value.split(separator: ".").map { String($0) })
-    }
-
-    static func parse(value parts: [String]) throws -> Value {
-        if parts.count == 1 {
-            switch parts[0] {
-            case "iterations":
-                return .iterations
-            case let base:
-                fatalError("Unrecognized base value: `\(base)`.")
-            }
-        } else {
-            switch parts[0] {
-            case "time":
-                return try parse(value: .time, parts: Array(parts.dropFirst()))
-            case "warmupTime":
-                return try parse(value: .warmupTime, parts: Array(parts.dropFirst()))
-            case "counter":
-                return try parse(value: .counter(parts[1]), parts: Array(parts.dropFirst(2)))
-            case "iterations":
-                return try parse(value: .iterations, parts: Array(parts.dropFirst()))
-            case "percentage":
-                return .percentage(try parse(value: Array(parts.dropFirst())))
-            case let base:
-                fatalError("Unrecognized base value: `\(base)`.")
-            }
-        }
-    }
-
-    static func parse(value base: Base, parts: [String]) throws -> Value {
-        if parts.count == 0 {
-            fatalError("Need to perform operation on base value \(base).")
-        }
-        var result: Value
-        switch parts[0] {
-        case "median":
-            result = .median(base)
-        case "std", "standardDeviation":
-            result = .std(base)
-        case "min", "minimum":
-            result = .min(base)
-        case "max", "maximum":
-            result = .max(base)
-        case "sum", "total":
-            result = .sum(base)
-        case "avg", "average":
-            result = .average(base)
-        case let op:
-            if op.hasPrefix("p") {
-                let numstr = parts[0].dropFirst().replacingOccurrences(of: "_", with: ".")
-                if let p = Double(numstr) {
-                    result = .percentile(p, base)
-                } else {
-                    fatalError("Can't parse percentile: \(parts[1]).")
-                }
-            } else {
-                fatalError("Can't perform `\(op)` on base value `\(base)`.")
-            }
-        }
-        if parts.count == 1 {
-            return result
-        } else {
-            return try parse(value: result, parts: Array(parts.dropFirst()))
-        }
-    }
-
-    static func parse(value: Value, parts: [String]) throws -> Value {
-        if parts.count == 0 {
-            return value
-        }
-        switch parts[0] {
-        case "div", "divide":
-            return .divide(value, try parse(value: Array(parts.dropFirst())))
-        case let op:
-            fatalError("Can't perform `\(op)` on value `\(value)`.")
-        }
-    }
-
-    static func name(customContent: CustomContent) -> String {
-        switch customContent {
-        case .name:
-            return "name"
-        case .value(let value):
-            return name(value: value)
-        }
-    }
-
-    static func name(value: Value) -> String {
-        switch value {
-        case .median(let arg):
-            return "\(name(base: arg)) (median)"
-        case .std(let arg):
-            return "\(name(base: arg)) (std)"
-        case .min(let arg):
-            return "\(name(base: arg)) (min)"
-        case .max(let arg):
-            return "\(name(base: arg)) (max)"
-        case .sum(let arg):
-            return "\(name(base: arg)) (total)"
-        case .average(let arg):
-            return "\(name(base: arg)) (avg)"
-        case .percentile(let p, let arg):
-            var string = String(p)
-            if string.hasSuffix(".0") {
-                string = String(string.dropLast(2))
-            }
-            return "\(name(base: arg)) (p\(string))"
-        case .counter(let counter):
-            return counter
-        case .divide(let lhs, let rhs):
-            return "\(name(value: lhs)) / \(name(value: rhs))"
-        case .percentage(let arg):
-            return "\(name(value: arg))"
-        case .iterations:
-            return "iterations"
-        }
-    }
-
-    static func name(base: Base) -> String {
-        switch base {
-        case .time:
-            return "time"
-        case .warmupTime:
-            return "warmup time"
-        }
-    }
-
-    static func validate(columns: String) throws {
-        let _ = try parse(columns: columns)
-        return
     }
 }

--- a/Sources/Benchmark/BenchmarkColumn.swift
+++ b/Sources/Benchmark/BenchmarkColumn.swift
@@ -47,8 +47,8 @@ public struct BenchmarkColumn: Hashable {
         self.formatter = formatter
     }
 
-    /// Registry stores associated between known column
-    /// names and their corresponding column values. This
+    /// Registry that represents a mapping from known column
+    /// names to their corresponding column values. This
     /// registry can be modified to add custom user-defined
     /// output columns.
     public static var registry: [String: BenchmarkColumn] = {

--- a/Sources/Benchmark/BenchmarkColumn.swift
+++ b/Sources/Benchmark/BenchmarkColumn.swift
@@ -1,0 +1,449 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+public struct BenchmarkColumn: Hashable {
+    typealias Column = BenchmarkColumn
+    typealias Row = [Column: String]
+
+    let name: String
+    let content: Content
+    let alignment: Alignment
+
+    init(name: String, content: Content, alignment: Alignment) {
+        self.name = name
+        self.content = content
+        self.alignment = alignment
+    }
+
+    static func defaults(results: [BenchmarkResult]) -> [Column] {
+        var columns = [
+            // name=:.name
+            Column(
+                name: "name",
+                content: .name,
+                alignment: .left),
+            // time=time.median:
+            Column(
+                name: "time",
+                content: .value(.median(.time)),
+                alignment: .right),
+            // std=:time.std.divide.time.median
+            Column(
+                name: "std",
+                content: .value(.percentage(.divide(.std(.time), .median(.time)))),
+                alignment: .left),
+            // iterations=iterations:
+            Column(
+                name: "iterations",
+                content: .value(.iterations),
+                alignment: .right),
+        ]
+        var counters: Set<String> = Set()
+        var showWarmup: Bool = false
+        for result in results {
+            showWarmup = showWarmup || result.warmupMeasurements.count > 0
+            for counter in result.counters.keys {
+                counters.insert(counter)
+            }
+        }
+        for counter in Array(counters).sorted() {
+            // counter_name=counter.counter_name:
+            columns.append(
+                Column(
+                    name: counter,
+                    content: .value(.counter(counter)),
+                    alignment: .right))
+        }
+        if showWarmup {
+            // warmup=warmupTime.sum:
+            columns.append(
+                Column(
+                    name: "warmup",
+                    content: .value(.sum(.warmupTime)),
+                    alignment: .right))
+        }
+        return columns
+    }
+
+    enum Content: Hashable {
+        case name
+        case value(Value)
+    }
+
+    enum Alignment: Hashable {
+        case left
+        case right
+    }
+
+    indirect enum Base: Hashable {
+        case time
+        case warmupTime
+    }
+
+    indirect enum Value: Hashable {
+        case median(Base)
+        case std(Base)
+        case min(Base)
+        case max(Base)
+        case sum(Base)
+        case average(Base)
+        case percentile(Double, Base)
+        case counter(String)
+        case iterations
+        case divide(Value, Value)
+        case percentage(Value)
+    }
+
+    enum Unit {
+        case none
+        case percentage
+        case time
+        case inverseTime
+    }
+
+    static func evaluate(columns: [Column], results: [BenchmarkResult]) -> [Row] {
+        var header: Row = [:]
+        for column in columns {
+            header[column] = column.name
+        }
+
+        var rows: [Row] = [header]
+        for result in results {
+            var row: Row = [:]
+            for column in columns {
+                row[column] = evaluate(content: column.content, result: result, pretty: true)
+            }
+            rows.append(row)
+        }
+
+        return rows
+    }
+
+    static func evaluate(content: Content, result: BenchmarkResult, pretty: Bool) -> String {
+        switch content {
+        case .name:
+            if result.suiteName != "" {
+                return "\(result.suiteName).\(result.benchmarkName)"
+            } else {
+                return result.benchmarkName
+            }
+        case .value(let value):
+            let evaluated = evaluate(value: value, result: result)
+            if !pretty {
+                return String(evaluated)
+            }
+            let suffix: String = containsStd(value) ? "± " : ""
+            switch unit(value) {
+            case .percentage:
+                return suffix + String(format: "%6.2f %%", evaluated)
+            case .time:
+                switch result.settings.timeUnit {
+                case .ns: return suffix + "\(evaluated) ns"
+                case .us: return suffix + "\(evaluated/1000.0) us"
+                case .ms: return suffix + "\(evaluated/1000_000.0) ms"
+                case .s: return suffix + "\(evaluated/1000_000_000.0) s"
+                }
+            case .inverseTime:
+                switch result.settings.inverseTimeUnit {
+                case .ns: return suffix + "\(evaluated) /ns"
+                case .us: return suffix + "\(evaluated*1000.0) /us"
+                case .ms: return suffix + "\(evaluated*1000_000.0) /ms"
+                case .s: return suffix + "\(evaluated*1000_000_000.0) /s"
+                }
+            case .none:
+                let string = String(evaluated)
+                if string.hasSuffix(".0") {
+                    return suffix + String(string.dropLast(2))
+                } else {
+                    return suffix + string
+                }
+            }
+        }
+    }
+
+    static func containsStd(_ value: Value) -> Bool {
+        switch value {
+        case .std(_):
+            return true
+        case .median(_), .min(_), .max(_), .sum(_), .average(_), .counter(_), .iterations,
+            .percentile(_, _):
+            return false
+        case .divide(let lhs, let rhs):
+            return containsStd(lhs) || containsStd(rhs)
+        case .percentage(let arg):
+            return containsStd(arg)
+        }
+    }
+
+    static func unit(_ value: Value) -> Unit {
+        switch value {
+        case .median(_), .std(_), .min(_), .max(_), .sum(_), .average(_), .percentile(_, _):
+            return .time
+        case .counter(_), .iterations:
+            return .none
+        case .divide(let lhs, let rhs):
+            switch (unit(lhs), unit(rhs)) {
+            case (.none, .time):
+                return .inverseTime
+            default:
+                return .none
+            }
+        case .percentage(_):
+            return .percentage
+        }
+    }
+
+    static func evaluate(base: Base, result: BenchmarkResult) -> [Double] {
+        switch base {
+        case .time:
+            return result.measurements
+        case .warmupTime:
+            return result.warmupMeasurements
+        }
+    }
+
+    static func evaluate(value: Value, result: BenchmarkResult) -> Double {
+        switch value {
+        case .median(let arg):
+            let base = evaluate(base: arg, result: result)
+            return base.median
+        case .std(let arg):
+            let base = evaluate(base: arg, result: result)
+            return base.std
+        case .min(let arg):
+            let base = evaluate(base: arg, result: result)
+            if let value = base.min() {
+                return value
+            } else {
+                return 0
+            }
+        case .max(let arg):
+            let base = evaluate(base: arg, result: result)
+            if let value = base.max() {
+                return value
+            } else {
+                return 0
+            }
+        case .sum(let arg):
+            let base = evaluate(base: arg, result: result)
+            return base.sum
+        case .average(let arg):
+            let base = evaluate(base: arg, result: result)
+            if base.count == 0 {
+                return 0
+            } else {
+                return base.average
+            }
+        case .percentile(let p, let arg):
+            let base = evaluate(base: arg, result: result)
+            if base.count == 0 {
+                return 0
+            } else {
+                return base.percentile(p)
+            }
+        case .counter(let counter):
+            if let value = result.counters[counter] {
+                return value
+            } else {
+                return 0
+            }
+        case .divide(let lhs, let rhs):
+            return evaluate(value: lhs, result: result) / evaluate(value: rhs, result: result)
+        case .percentage(let arg):
+            return evaluate(value: arg, result: result) * 100.0
+        case .iterations:
+            return Double(result.measurements.count)
+        }
+    }
+
+    static func parse(columns: String) throws -> [Column] {
+        if columns.contains(",") {
+            var result: [Column] = []
+            for column in columns.split(separator: ",") {
+                result.append(try parse(column: String(column)))
+            }
+            return result
+        } else {
+            return [try parse(column: columns)]
+        }
+    }
+
+    static func parse(column: String) throws -> Column {
+        var columnName = ""
+        var alignment: Alignment = .left
+        var rest = column
+
+        if rest.contains("=") {
+            let nameParts = rest.split(separator: "=", maxSplits: 2)
+            columnName = String(nameParts[0])
+            rest = String(nameParts[1])
+        }
+        if rest.first == ":" {
+            alignment = .left
+            rest = String(rest.dropFirst())
+        }
+        if rest.last == ":" {
+            alignment = .right
+            rest = String(rest.dropLast())
+        }
+
+        let content = try parse(content: rest)
+        if columnName == "" {
+            columnName = name(content: content)
+        }
+
+        return Column(name: columnName, content: content, alignment: alignment)
+    }
+
+    static func parse(content: String) throws -> Content {
+        if content == "name" {
+            return .name
+        } else {
+            return .value(try parse(value: content))
+        }
+    }
+
+    static func parse(value: String) throws -> Value {
+        try parse(value: value.split(separator: ".").map { String($0) })
+    }
+
+    static func parse(value parts: [String]) throws -> Value {
+        if parts.count == 1 {
+            switch parts[0] {
+            case "iterations":
+                return .iterations
+            case let base:
+                fatalError("Unrecognized base value: `\(base)`.")
+            }
+        } else {
+            switch parts[0] {
+            case "time":
+                return try parse(value: .time, parts: Array(parts.dropFirst()))
+            case "warmupTime":
+                return try parse(value: .warmupTime, parts: Array(parts.dropFirst()))
+            case "counter":
+                return try parse(value: .counter(parts[1]), parts: Array(parts.dropFirst(2)))
+            case "iterations":
+                return try parse(value: .iterations, parts: Array(parts.dropFirst()))
+            case "percentage":
+                return .percentage(try parse(value: Array(parts.dropFirst())))
+            case let base:
+                fatalError("Unrecognized base value: `\(base)`.")
+            }
+        }
+    }
+
+    static func parse(value base: Base, parts: [String]) throws -> Value {
+        if parts.count == 0 {
+            fatalError("Need to perform operation on base value \(base).")
+        }
+        var result: Value
+        switch parts[0] {
+        case "median":
+            result = .median(base)
+        case "std", "standardDeviation":
+            result = .std(base)
+        case "min", "minimum":
+            result = .min(base)
+        case "max", "maximum":
+            result = .max(base)
+        case "sum", "total":
+            result = .sum(base)
+        case "avg", "average":
+            result = .average(base)
+        case let op:
+            if op.hasPrefix("p") {
+                let numstr = parts[0].dropFirst().replacingOccurrences(of: "_", with: ".")
+                if let p = Double(numstr) {
+                    result = .percentile(p, base)
+                } else {
+                    fatalError("Can't parse percentile: \(parts[1]).")
+                }
+            } else {
+                fatalError("Can't perform `\(op)` on base value `\(base)`.")
+            }
+        }
+        if parts.count == 1 {
+            return result
+        } else {
+            return try parse(value: result, parts: Array(parts.dropFirst()))
+        }
+    }
+
+    static func parse(value: Value, parts: [String]) throws -> Value {
+        if parts.count == 0 {
+            return value
+        }
+        switch parts[0] {
+        case "div", "divide":
+            return .divide(value, try parse(value: Array(parts.dropFirst())))
+        case let op:
+            fatalError("Can't perform `\(op)` on value `\(value)`.")
+        }
+    }
+
+    static func name(content: Content) -> String {
+        switch content {
+        case .name:
+            return "name"
+        case .value(let value):
+            return name(value: value)
+        }
+    }
+
+    static func name(value: Value) -> String {
+        switch value {
+        case .median(let arg):
+            return "\(name(base: arg)) (median)"
+        case .std(let arg):
+            return "\(name(base: arg)) (std)"
+        case .min(let arg):
+            return "\(name(base: arg)) (min)"
+        case .max(let arg):
+            return "\(name(base: arg)) (max)"
+        case .sum(let arg):
+            return "\(name(base: arg)) (total)"
+        case .average(let arg):
+            return "\(name(base: arg)) (avg)"
+        case .percentile(let p, let arg):
+            var string = String(p)
+            if string.hasSuffix(".0") {
+                string = String(string.dropLast(2))
+            }
+            return "\(name(base: arg)) (p\(string))"
+        case .counter(let counter):
+            return counter
+        case .divide(let lhs, let rhs):
+            return "\(name(value: lhs)) / \(name(value: rhs))"
+        case .percentage(let arg):
+            return "\(name(value: arg))"
+        case .iterations:
+            return "iterations"
+        }
+    }
+
+    static func name(base: Base) -> String {
+        switch base {
+        case .time:
+            return "time"
+        case .warmupTime:
+            return "warmup time"
+        }
+    }
+
+    static func validate(columns: String) throws {
+        let _ = try parse(columns: columns)
+        return
+    }
+}

--- a/Sources/Benchmark/BenchmarkFormatter.swift
+++ b/Sources/Benchmark/BenchmarkFormatter.swift
@@ -1,0 +1,63 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Functions for pretty column output formatting.
+public enum BenchmarkFormatter {
+    public typealias Formatter = (Double, BenchmarkSettings) -> String
+
+    /// Just show a number, stripping ".0" if it's integer.
+    public static let number: Formatter = { (value, settings) in
+        let string = String(value)
+        if string.hasSuffix(".0") {
+            return String(string.dropLast(2))
+        } else {
+            return string
+        }
+    }
+
+    /// Show number with the corresponding time unit.
+    public static let time: Formatter = { (value, settings) in
+        switch settings.timeUnit {
+        case .ns: return "\(value) ns"
+        case .us: return "\(value/1000.0) us"
+        case .ms: return "\(value/1000_000.0) ms"
+        case .s: return "\(value/1000_000_000.0) s"
+        }
+    }
+
+    /// Show number with the corresponding inverse time unit.
+    public static let inverseTime: Formatter = { (value, settings) in
+        switch settings.inverseTimeUnit {
+        case .ns: return "\(value) /ns"
+        case .us: return "\(value*1000.0) /us"
+        case .ms: return "\(value*1000_000.0) /ms"
+        case .s: return "\(value*1000_000_000.0) /s"
+        }
+    }
+
+    /// Show value as percentage.
+    public static let percentage: Formatter = { (value, settings) in
+        return String(format: "%6.2f %%", value)
+    }
+
+    /// Show value as plus or minus standard deviation.
+    public static let std: Formatter = { (value, settings) in
+        return "± " + String(value)
+    }
+
+    /// Show value as plus or minus standard deviation in percentage.
+    public static let stdPercentage: Formatter = { (value, settings) in
+        return "± " + String(format: "%6.2f %%", value)
+    }
+}

--- a/Sources/Benchmark/BenchmarkReporter.swift
+++ b/Sources/Benchmark/BenchmarkReporter.swift
@@ -49,9 +49,11 @@ struct PlainTextReporter<Target>: BenchmarkReporter where Target: TextOutputStre
     }
 
     mutating func report(results: [BenchmarkResult], settings: BenchmarkSettings) {
-        let columns: [Column]
-        if let value = settings.columns {
-            columns = value
+        var columns: [Column] = []
+        if let names = settings.columns {
+            for name in names {
+                columns.append(BenchmarkColumn.registry[name]!)
+            }
         } else {
             columns = BenchmarkColumn.defaults(results: results)
         }

--- a/Sources/Benchmark/BenchmarkReporter.swift
+++ b/Sources/Benchmark/BenchmarkReporter.swift
@@ -55,7 +55,7 @@ struct PlainTextReporter<Target>: BenchmarkReporter where Target: TextOutputStre
         } else {
             columns = BenchmarkColumn.defaults(results: results)
         }
-        let rows = BenchmarkColumn.evaluate(columns: columns, results: results)
+        let rows = BenchmarkColumn.evaluate(columns: columns, results: results, pretty: true)
 
         let widths: [Column: Int] = Dictionary(
             uniqueKeysWithValues:

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -28,7 +28,11 @@ public struct BenchmarkRunner {
         for suite in suites {
             try run(suite: suite)
         }
-        reporter.report(results: results)
+        let globalSettings = BenchmarkSettings([
+            defaultSettings,
+            self.settings,
+        ])
+        reporter.report(results: results, settings: globalSettings)
     }
 
     mutating func run(suite: BenchmarkSuite) throws {

--- a/Sources/Benchmark/BenchmarkSetting.swift
+++ b/Sources/Benchmark/BenchmarkSetting.swift
@@ -63,7 +63,7 @@ public struct MinTime: BenchmarkSetting {
     }
 }
 
-/// Time unit for reporting results.
+/// Time unit for reporting time results.
 public struct TimeUnit: BenchmarkSetting {
     public var value: Value
     public init(_ value: Value) {
@@ -77,7 +77,7 @@ public struct TimeUnit: BenchmarkSetting {
     }
 }
 
-/// Time unit for reporting results.
+/// Time unit for reporting throughput results.
 public struct InverseTimeUnit: BenchmarkSetting {
     public var value: TimeUnit.Value
     public init(_ value: TimeUnit.Value) {

--- a/Sources/Benchmark/BenchmarkSetting.swift
+++ b/Sources/Benchmark/BenchmarkSetting.swift
@@ -188,7 +188,7 @@ public struct BenchmarkSettings {
         }
     }
 
-    /// Convenience accessor for the TimeUnit setting. 
+    /// Convenience accessor for the InverseTimeUnit setting. 
     public var inverseTimeUnit: TimeUnit.Value {
         if let value = self[InverseTimeUnit.self]?.value {
             return value
@@ -197,7 +197,7 @@ public struct BenchmarkSettings {
         }
     }
 
-    /// Convenience accessor for the TimeUnit setting. 
+    /// Convenience accessor for the Columns setting. 
     public var columns: [String]? {
         return self[Columns.self]?.value
     }

--- a/Sources/Benchmark/BenchmarkSetting.swift
+++ b/Sources/Benchmark/BenchmarkSetting.swift
@@ -87,11 +87,8 @@ public struct InverseTimeUnit: BenchmarkSetting {
 
 /// Columns to show in the benchmark output.
 public struct Columns: BenchmarkSetting {
-    public var value: [BenchmarkColumn]
-    public init(_ value: String) throws {
-        self.value = try BenchmarkColumn.parse(columns: value)
-    }
-    public init(_ value: [BenchmarkColumn]) {
+    public var value: [String]
+    public init(_ value: [String]) {
         self.value = value
     }
 }
@@ -201,7 +198,7 @@ public struct BenchmarkSettings {
     }
 
     /// Convenience accessor for the TimeUnit setting. 
-    public var columns: [BenchmarkColumn]? {
+    public var columns: [String]? {
         return self[Columns.self]?.value
     }
 }

--- a/Sources/Benchmark/BenchmarkSetting.swift
+++ b/Sources/Benchmark/BenchmarkSetting.swift
@@ -77,6 +77,25 @@ public struct TimeUnit: BenchmarkSetting {
     }
 }
 
+/// Time unit for reporting results.
+public struct InverseTimeUnit: BenchmarkSetting {
+    public var value: TimeUnit.Value
+    public init(_ value: TimeUnit.Value) {
+        self.value = value
+    }
+}
+
+/// Columns to show in the benchmark output.
+public struct Columns: BenchmarkSetting {
+    public var value: [BenchmarkColumn]
+    public init(_ value: String) throws {
+        self.value = try BenchmarkColumn.parse(columns: value)
+    }
+    public init(_ value: [BenchmarkColumn]) {
+        self.value = value
+    }
+}
+
 /// An aggregate of all benchmark settings, that deduplicates
 /// the settings based on their type. A setting which is defined
 /// multiple times, only retains its last set value.
@@ -171,10 +190,25 @@ public struct BenchmarkSettings {
             fatalError("timeUnit must have a default.")
         }
     }
+
+    /// Convenience accessor for the TimeUnit setting. 
+    public var inverseTimeUnit: TimeUnit.Value {
+        if let value = self[InverseTimeUnit.self]?.value {
+            return value
+        } else {
+            fatalError("inverseTimeUnit must have a default.")
+        }
+    }
+
+    /// Convenience accessor for the TimeUnit setting. 
+    public var columns: [BenchmarkColumn]? {
+        return self[Columns.self]?.value
+    }
 }
 
 let defaultSettings: [BenchmarkSetting] = [
     MaxIterations(1_000_000),
     MinTime(seconds: 1.0),
     TimeUnit(.ns),
+    InverseTimeUnit(.s),
 ]

--- a/Sources/Benchmark/Stats.swift
+++ b/Sources/Benchmark/Stats.swift
@@ -26,6 +26,10 @@ extension Array where Element == Double {
         return total
     }
 
+    var average: Double {
+        return sum / Double(count)
+    }
+
     var sumSquared: Double {
         var total: Double = 0
         for x in self {
@@ -69,5 +73,31 @@ extension Array where Element == Double {
         let meanValue = mean
         let avgSquares = sumSquared * (1.0 / c)
         return (c / (c - 1) * (avgSquares - meanValue * meanValue)).squareRoot()
+    }
+
+    func percentile(_ v: Double) -> Double {
+        if v < 0 {
+            fatalError("Percentile can not be negative.")
+        }
+        if v > 100 {
+            fatalError("Percentile can not be more than 100.")
+        }
+        if count == 0 {
+            return 0
+        }
+        let sorted = self.sorted()
+        let p = v / 100.0
+        let index = (Double(count) - 1) * p
+        var low = index
+        low.round(.down)
+        var high = index
+        high.round(.up)
+        if low == high {
+            return sorted[Int(low)]
+        } else {
+            let lowValue = sorted[Int(low)] * (high - index)
+            let highValue = sorted[Int(high)] * (index - low)
+            return lowValue + highValue
+        }
     }
 }

--- a/Tests/BenchmarkTests/BenchmarkColumnTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkColumnTests.swift
@@ -52,43 +52,12 @@ final class BenchmarkColumnTests: XCTestCase {
         ),
     ]
 
-    static var contentExamples: [(String, BenchmarkColumn.Content)] {
-        var result: [(String, BenchmarkColumn.Content)] = [
+    static var contentExamples: [(String, BenchmarkColumn.CustomContent)] {
+        var result: [(String, BenchmarkColumn.CustomContent)] = [
             ("name", .name)
         ]
         for (string, value) in BenchmarkColumnTests.valueExamples {
             result.append((string, .value(value)))
-        }
-        return result
-    }
-
-    static var columnNames = [
-        "time",
-        "time (ns)",
-        "time median",
-        "time std",
-        "time std (%)",
-        "foo",
-        "foo bar",
-    ]
-
-    static var alignments: [BenchmarkColumn.Alignment] = [
-        .left,
-        .right,
-    ]
-
-    static var columnExamples: [(String, BenchmarkColumn)] {
-        var result: [(String, BenchmarkColumn)] = []
-        for name in BenchmarkColumnTests.columnNames {
-            for alignment in BenchmarkColumnTests.alignments {
-                for (content, contentExpected) in BenchmarkColumnTests.contentExamples {
-                    let rhs = alignment == .left ? ":\(content)" : "\(content):"
-                    let string = "\(name)=\(rhs)"
-                    let expected = BenchmarkColumn(
-                        name: name, content: contentExpected, alignment: alignment)
-                    result.append((string, expected))
-                }
-            }
         }
         return result
     }
@@ -102,34 +71,13 @@ final class BenchmarkColumnTests: XCTestCase {
 
     func testParseContent() throws {
         for (string, expected) in BenchmarkColumnTests.contentExamples {
-            let parsed = try BenchmarkColumn.parse(content: string)
+            let parsed = try BenchmarkColumn.parse(customContent: string)
             XCTAssertEqual(parsed, expected, "content: \(string)")
-        }
-    }
-
-    func testParseColumn() throws {
-        for (string, expected) in BenchmarkColumnTests.columnExamples {
-            let parsed = try BenchmarkColumn.parse(column: string)
-            XCTAssertEqual(parsed, expected, "column: \(string)")
-
-        }
-    }
-
-    func testParseColumns() throws {
-        for (string1, expected1) in BenchmarkColumnTests.columnExamples {
-            for (string2, expected2) in BenchmarkColumnTests.columnExamples {
-                let string = "\(string1),\(string2)"
-                let parsed = try BenchmarkColumn.parse(columns: string)
-                let expected = [expected1, expected2]
-                XCTAssertEqual(parsed, expected, "columns: \(string)")
-            }
         }
     }
 
     static var allTests = [
         ("testParseValue", testParseValue),
         ("testParseContent", testParseContent),
-        ("testParseColumn", testParseColumn),
-        ("testParseColumns", testParseColumns),
     ]
 }

--- a/Tests/BenchmarkTests/BenchmarkColumnTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkColumnTests.swift
@@ -17,67 +17,37 @@ import XCTest
 @testable import Benchmark
 
 final class BenchmarkColumnTests: XCTestCase {
-    static var valueExamples: [(String, BenchmarkColumn.Value)] = [
-        ("time.sum", .sum(.time)),
-        ("time.median", .median(.time)),
-        ("time.std", .std(.time)),
-        ("time.standardDeviation", .std(.time)),
-        ("time.min", .min(.time)),
-        ("time.minimum", .min(.time)),
-        ("time.max", .max(.time)),
-        ("time.maximum", .max(.time)),
-        ("time.avg", .average(.time)),
-        ("time.average", .average(.time)),
-        ("time.p5", .percentile(5, .time)),
-        ("time.p50", .percentile(50, .time)),
-        ("time.p99_9", .percentile(99.9, .time)),
-        ("warmupTime.sum", .sum(.warmupTime)),
-        ("warmupTime.median", .median(.warmupTime)),
-        ("warmupTime.std", .std(.warmupTime)),
-        ("warmupTime.standardDeviation", .std(.warmupTime)),
-        ("warmupTime.min", .min(.warmupTime)),
-        ("warmupTime.minimum", .min(.warmupTime)),
-        ("warmupTime.max", .max(.warmupTime)),
-        ("warmupTime.maximum", .max(.warmupTime)),
-        ("warmupTime.avg", .average(.warmupTime)),
-        ("warmupTime.average", .average(.warmupTime)),
-        ("counter.foo", .counter("foo")),
-        ("counter.foo.div.time.sum", .divide(.counter("foo"), .sum(.time))),
-        ("counter.foo.divide.time.sum", .divide(.counter("foo"), .sum(.time))),
-        ("counter.foo.divide.time.average", .divide(.counter("foo"), .average(.time))),
-        ("time.std.divide.time.median", .divide(.std(.time), .median(.time))),
-        (
-            "percentage.time.std.divide.time.median",
-            .percentage(.divide(.std(.time), .median(.time)))
-        ),
-    ]
-
-    static var contentExamples: [(String, BenchmarkColumn.CustomContent)] {
-        var result: [(String, BenchmarkColumn.CustomContent)] = [
-            ("name", .name)
+    func testKnownColumns() {
+        let columns = [
+            "name",
+            "time",
+            "std",
+            "iterations",
+            "warmup",
+            "median",
+            "min",
+            "max",
+            "total",
+            "avg",
+            "average",
+            "std_abs",
+            "p0",
+            "p1",
+            "p5",
+            "p10",
+            "p50",
+            "p90",
+            "p99",
+            "p99.9",
+            "p99.99",
+            "p100",
         ]
-        for (string, value) in BenchmarkColumnTests.valueExamples {
-            result.append((string, .value(value)))
-        }
-        return result
-    }
-
-    func testParseValue() throws {
-        for (string, expected) in BenchmarkColumnTests.valueExamples {
-            let parsed = try BenchmarkColumn.parse(value: string)
-            XCTAssertEqual(parsed, expected, "value: \(string)")
-        }
-    }
-
-    func testParseContent() throws {
-        for (string, expected) in BenchmarkColumnTests.contentExamples {
-            let parsed = try BenchmarkColumn.parse(customContent: string)
-            XCTAssertEqual(parsed, expected, "content: \(string)")
+        for name in columns {
+            XCTAssertTrue(BenchmarkColumn.registry[name] != nil, "Column: \(name).")
         }
     }
 
     static var allTests = [
-        ("testParseValue", testParseValue),
-        ("testParseContent", testParseContent),
+        ("testKnownColumns", testKnownColumns)
     ]
 }

--- a/Tests/BenchmarkTests/BenchmarkColumnTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkColumnTests.swift
@@ -1,0 +1,135 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import Benchmark
+
+final class BenchmarkColumnTests: XCTestCase {
+    static var valueExamples: [(String, BenchmarkColumn.Value)] = [
+        ("time.sum", .sum(.time)),
+        ("time.median", .median(.time)),
+        ("time.std", .std(.time)),
+        ("time.standardDeviation", .std(.time)),
+        ("time.min", .min(.time)),
+        ("time.minimum", .min(.time)),
+        ("time.max", .max(.time)),
+        ("time.maximum", .max(.time)),
+        ("time.avg", .average(.time)),
+        ("time.average", .average(.time)),
+        ("time.p5", .percentile(5, .time)),
+        ("time.p50", .percentile(50, .time)),
+        ("time.p99_9", .percentile(99.9, .time)),
+        ("warmupTime.sum", .sum(.warmupTime)),
+        ("warmupTime.median", .median(.warmupTime)),
+        ("warmupTime.std", .std(.warmupTime)),
+        ("warmupTime.standardDeviation", .std(.warmupTime)),
+        ("warmupTime.min", .min(.warmupTime)),
+        ("warmupTime.minimum", .min(.warmupTime)),
+        ("warmupTime.max", .max(.warmupTime)),
+        ("warmupTime.maximum", .max(.warmupTime)),
+        ("warmupTime.avg", .average(.warmupTime)),
+        ("warmupTime.average", .average(.warmupTime)),
+        ("counter.foo", .counter("foo")),
+        ("counter.foo.div.time.sum", .divide(.counter("foo"), .sum(.time))),
+        ("counter.foo.divide.time.sum", .divide(.counter("foo"), .sum(.time))),
+        ("counter.foo.divide.time.average", .divide(.counter("foo"), .average(.time))),
+        ("time.std.divide.time.median", .divide(.std(.time), .median(.time))),
+        (
+            "percentage.time.std.divide.time.median",
+            .percentage(.divide(.std(.time), .median(.time)))
+        ),
+    ]
+
+    static var contentExamples: [(String, BenchmarkColumn.Content)] {
+        var result: [(String, BenchmarkColumn.Content)] = [
+            ("name", .name)
+        ]
+        for (string, value) in BenchmarkColumnTests.valueExamples {
+            result.append((string, .value(value)))
+        }
+        return result
+    }
+
+    static var columnNames = [
+        "time",
+        "time (ns)",
+        "time median",
+        "time std",
+        "time std (%)",
+        "foo",
+        "foo bar",
+    ]
+
+    static var alignments: [BenchmarkColumn.Alignment] = [
+        .left,
+        .right,
+    ]
+
+    static var columnExamples: [(String, BenchmarkColumn)] {
+        var result: [(String, BenchmarkColumn)] = []
+        for name in BenchmarkColumnTests.columnNames {
+            for alignment in BenchmarkColumnTests.alignments {
+                for (content, contentExpected) in BenchmarkColumnTests.contentExamples {
+                    let rhs = alignment == .left ? ":\(content)" : "\(content):"
+                    let string = "\(name)=\(rhs)"
+                    let expected = BenchmarkColumn(
+                        name: name, content: contentExpected, alignment: alignment)
+                    result.append((string, expected))
+                }
+            }
+        }
+        return result
+    }
+
+    func testParseValue() throws {
+        for (string, expected) in BenchmarkColumnTests.valueExamples {
+            let parsed = try BenchmarkColumn.parse(value: string)
+            XCTAssertEqual(parsed, expected, "value: \(string)")
+        }
+    }
+
+    func testParseContent() throws {
+        for (string, expected) in BenchmarkColumnTests.contentExamples {
+            let parsed = try BenchmarkColumn.parse(content: string)
+            XCTAssertEqual(parsed, expected, "content: \(string)")
+        }
+    }
+
+    func testParseColumn() throws {
+        for (string, expected) in BenchmarkColumnTests.columnExamples {
+            let parsed = try BenchmarkColumn.parse(column: string)
+            XCTAssertEqual(parsed, expected, "column: \(string)")
+
+        }
+    }
+
+    func testParseColumns() throws {
+        for (string1, expected1) in BenchmarkColumnTests.columnExamples {
+            for (string2, expected2) in BenchmarkColumnTests.columnExamples {
+                let string = "\(string1),\(string2)"
+                let parsed = try BenchmarkColumn.parse(columns: string)
+                let expected = [expected1, expected2]
+                XCTAssertEqual(parsed, expected, "columns: \(string)")
+            }
+        }
+    }
+
+    static var allTests = [
+        ("testParseValue", testParseValue),
+        ("testParseContent", testParseContent),
+        ("testParseColumn", testParseColumn),
+        ("testParseColumns", testParseColumns),
+    ]
+}

--- a/Tests/BenchmarkTests/BenchmarkReporterTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkReporterTests.swift
@@ -21,7 +21,7 @@ final class BenchmarkReporterTests: XCTestCase {
         let output = MockTextOutputStream()
         var reporter = PlainTextReporter(to: output)
 
-        reporter.report(results: results)
+        reporter.report(results: results, settings: BenchmarkSettings())
 
         let expectedLines = expected.split(separator: "\n").map { String($0) }
         let actual = output.lines.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
@@ -73,8 +73,8 @@ final class BenchmarkReporterTests: XCTestCase {
         let expected = #"""
             name         time         std        iterations foo
             ---------------------------------------------------
-            MySuite.fast    1500.0 ns ±  47.14 %          2 7.0
-            MySuite.slow 1500000.0 ns ±  47.14 %          2
+            MySuite.fast    1500.0 ns ±  47.14 %          2   7
+            MySuite.slow 1500000.0 ns ±  47.14 %          2   0
             """#
         assertIsPrintedAs(results, expected)
     }
@@ -98,7 +98,7 @@ final class BenchmarkReporterTests: XCTestCase {
             name         time         std        iterations warmup
             -------------------------------------------------------
             MySuite.fast    1500.0 ns ±  47.14 %          2 60.0 ns
-            MySuite.slow 1500000.0 ns ±  47.14 %          2
+            MySuite.slow 1500000.0 ns ±  47.14 %          2  0.0 ns
             """#
         assertIsPrintedAs(results, expected)
     }

--- a/Tests/BenchmarkTests/BlackHoleReporter.swift
+++ b/Tests/BenchmarkTests/BlackHoleReporter.swift
@@ -17,5 +17,5 @@
 struct BlackHoleReporter: BenchmarkReporter {
     func report(running name: String, suite: String) {}
     func report(finishedRunning name: String, suite: String, nanosTaken: UInt64) {}
-    func report(results: [BenchmarkResult]) {}
+    func report(results: [BenchmarkResult], settings: BenchmarkSettings) {}
 }

--- a/Tests/BenchmarkTests/XCTTestManifests.swift
+++ b/Tests/BenchmarkTests/XCTTestManifests.swift
@@ -17,6 +17,7 @@ import XCTest
 #if !canImport(ObjectiveC)
     public func allTests() -> [XCTestCaseEntry] {
         return [
+            testCase(BenchmarkColumnTests.allTests),
             testCase(BenchmarkCommandTests.allTests),
             testCase(BenchmarkReporterTests.allTests),
             testCase(BenchmarkRunnerTests.allTests),


### PR DESCRIPTION
This PR adds a new flag that lets one define what columns should be shown. For example:
```
$ swift run -c release BenchmarkMinimalExample --columns name,min,p50,max,iterations                                                                                                
[3/3] Linking BenchmarkMinimalExample                                                                                                                                               
running add string no capacity... done! (1823.01 ms)                                                                                                                                
running add string reserved capacity... done! (1815.29 ms)                                                                                                                          
                                                                                                                                                                                    
name                         min        p50        max         iterations                                                                                                           
-------------------------------------------------------------------------                                                                                                           
add string no capacity       37434.0 ns 37559.0 ns 106884.0 ns      37163                                                                                                           
add string reserved capacity 36994.0 ns 37031.0 ns  90842.0 ns      37722  
```

A brief overview of features: 

* It supports a wide set of columns:  `min`, `max`, `pN`, `median`, `avg`, `total`, ... (see tests for complete list).

* Users can define columns by inserting their custom columns into `BenchmarkColumn.registry`. Column is defined by name, a function to compute it's contents and an optional formatter for pretty output. 

Fixes #15