### PR TITLE
Allow for 0 --warmup-iterations

### DIFF
--- a/Sources/Benchmark/BenchmarkArguments.swift
+++ b/Sources/Benchmark/BenchmarkArguments.swift
@@ -75,8 +75,9 @@ public struct BenchmarkArguments: ParsableArguments {
         if iterations != nil && iterations! <= 0 {
             throw ValidationError(positiveNumberError(flag: "--iterations", of: "integer"))
         }
-        if warmupIterations != nil && warmupIterations! <= 0 {
-            throw ValidationError(positiveNumberError(flag: "--warmup-iterations", of: "integer"))
+        if warmupIterations != nil && warmupIterations! < 0 {
+            throw ValidationError(
+                nonNegativeNumberError(flag: "--warmup-iterations", of: "integer"))
         }
         if maxIterations != nil && maxIterations! <= 0 {
             throw ValidationError(positiveNumberError(flag: "--max-iterations", of: "integer"))
@@ -98,5 +99,9 @@ public struct BenchmarkArguments: ParsableArguments {
 
     func positiveNumberError(flag: String, of type: String) -> String {
         return "Value provided via \(flag) must be a positive \(type)."
+    }
+
+    func nonNegativeNumberError(flag: String, of type: String) -> String {
+        return "Value provided via \(flag) must be a non-negative \(type)."
     }
 }

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -54,8 +54,9 @@ public struct BenchmarkRunner {
         let totalStart = now()
 
         var warmupState: BenchmarkState? = nil
-        if let n = settings.warmupIterations {
-            warmupState = doNIterations(n, benchmark: benchmark, suite: suite, settings: settings)
+        if settings.warmupIterations > 0 {
+            warmupState = doNIterations(
+                settings.warmupIterations, benchmark: benchmark, suite: suite, settings: settings)
         }
 
         var state: BenchmarkState

--- a/Sources/Benchmark/BenchmarkSetting.swift
+++ b/Sources/Benchmark/BenchmarkSetting.swift
@@ -125,8 +125,12 @@ public struct BenchmarkSettings {
     }
 
     /// Convenience accessor for WarmupIterations setting.
-    public var warmupIterations: Int? {
-        return self[WarmupIterations.self]?.value
+    public var warmupIterations: Int {
+        if let value = self[WarmupIterations.self]?.value {
+            return value
+        } else {
+            return 0
+        }
     }
 
     /// Convenience accessor for the Filter setting.

--- a/Tests/BenchmarkTests/BenchmarkCommandTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkCommandTests.swift
@@ -79,6 +79,12 @@ final class BenchmarkCommandTests: XCTestCase {
         }
     }
 
+    func testParseNoWarmupIterations() throws {
+        AssertParse(["--allow-debug-build"]) { settings in
+            XCTAssertEqual(settings.warmupIterations, 0)
+        }
+    }
+
     func testParseMaxIterations() throws {
         AssertParse(["--max-iterations", "42", "--allow-debug-build"]) { settings in
             XCTAssertEqual(settings.maxIterations, 42)
@@ -111,6 +117,7 @@ final class BenchmarkCommandTests: XCTestCase {
         ("testParseZeroIterationsError", testParseZeroIterationsError),
         ("testParseWarmupIterations", testParseWarmupIterations),
         ("testParseZeroWarmupIterations", testParseZeroWarmupIterations),
+        ("testParseNoWarmupIterations", testParseNoWarmupIterations),
         ("testParseMaxIterations", testParseWarmupIterations),
         ("testParseZeroMaxIterationsError", testParseZeroMaxIterationsError),
         ("testParseMinTime", testParseMinTime),

--- a/Tests/BenchmarkTests/BenchmarkCommandTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkCommandTests.swift
@@ -73,10 +73,10 @@ final class BenchmarkCommandTests: XCTestCase {
         }
     }
 
-    func testParseZeroWarmupIterationsError() throws {
-        AssertFailsToParse(
-            ["--warmup-iterations", "0", "--allow-debug-build"],
-            with: "Value provided via --warmup-iterations must be a positive integer.")
+    func testParseZeroWarmupIterations() throws {
+        AssertParse(["--warmup-iterations", "0", "--allow-debug-build"]) { settings in
+            XCTAssertEqual(settings.warmupIterations, 0)
+        }
     }
 
     func testParseMaxIterations() throws {
@@ -87,7 +87,7 @@ final class BenchmarkCommandTests: XCTestCase {
 
     func testParseZeroMaxIterationsError() throws {
         AssertFailsToParse(
-            ["--warmup-iterations", "0", "--allow-debug-build"],
+            ["--max-iterations", "0", "--allow-debug-build"],
             with: "Value provided via --max-iterations must be a positive integer.")
     }
 
@@ -110,9 +110,9 @@ final class BenchmarkCommandTests: XCTestCase {
         ("testParseIterations", testParseIterations),
         ("testParseZeroIterationsError", testParseZeroIterationsError),
         ("testParseWarmupIterations", testParseWarmupIterations),
-        ("testParseZeroWarmupIterationsError", testParseZeroWarmupIterationsError),
+        ("testParseZeroWarmupIterations", testParseZeroWarmupIterations),
         ("testParseMaxIterations", testParseWarmupIterations),
-        ("testParseZeroMaxIterationsError", testParseZeroWarmupIterationsError),
+        ("testParseZeroMaxIterationsError", testParseZeroMaxIterationsError),
         ("testParseMinTime", testParseMinTime),
         ("testParseZeroMinTimeError", testParseZeroMinTimeError),
     ]


### PR DESCRIPTION
This change makes treatment of absent or 0 warmup iterations more consistent. There is no need to differentiate between unset warmup iterations setting and warmup iterations explicitly set to 0.