### PR TITLE
Allow 0 --iterations

### DIFF
--- a/Sources/Benchmark/BenchmarkArguments.swift
+++ b/Sources/Benchmark/BenchmarkArguments.swift
@@ -78,8 +78,9 @@ public struct BenchmarkArguments: ParsableArguments {
         if isDebug && !allowDebugBuild {
             throw ValidationError(debugBuildErrorMessage)
         }
-        if iterations != nil && iterations! <= 0 {
-            throw ValidationError(positiveNumberError(flag: "--iterations", of: "integer"))
+        if iterations != nil && iterations! < 0 {
+            throw ValidationError(
+                nonNegativeNumberError(flag: "--iterations", of: "integer"))
         }
         if warmupIterations != nil && warmupIterations! < 0 {
             throw ValidationError(

--- a/Tests/BenchmarkTests/BenchmarkCommandTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkCommandTests.swift
@@ -61,10 +61,10 @@ final class BenchmarkCommandTests: XCTestCase {
         }
     }
 
-    func testParseZeroIterationsError() throws {
-        AssertFailsToParse(
-            ["--iterations", "0", "--allow-debug-build"],
-            with: "Value provided via --iterations must be a positive integer.")
+    func testParseZeroIterations() throws {
+        AssertParse(["--iterations", "0", "--allow-debug-build"]) { settings in
+            XCTAssertEqual(settings.iterations, 0)
+        }
     }
 
     func testParseWarmupIterations() throws {
@@ -114,7 +114,7 @@ final class BenchmarkCommandTests: XCTestCase {
         ("testDebugBuildError", testDebugBuildError),
         ("testParseFilter", testParseFilter),
         ("testParseIterations", testParseIterations),
-        ("testParseZeroIterationsError", testParseZeroIterationsError),
+        ("testParseZeroIterations", testParseZeroIterations),
         ("testParseWarmupIterations", testParseWarmupIterations),
         ("testParseZeroWarmupIterations", testParseZeroWarmupIterations),
         ("testParseNoWarmupIterations", testParseNoWarmupIterations),


### PR DESCRIPTION
It's useful to print benchmark results without actually running benchmarks to enumerate all available benchmarks while interacting with benchmarks programmatically. 