### PR TITLE
Add support for custom default settings

### DIFF
--- a/Sources/Benchmark/BenchmarkArguments.swift
+++ b/Sources/Benchmark/BenchmarkArguments.swift
@@ -138,3 +138,8 @@ public struct BenchmarkArguments: ParsableArguments {
         return "Value provided via \(flag) must be a non-negative \(type)."
     }
 }
+
+public func parseArguments() -> [BenchmarkSetting] {
+    let command = BenchmarkCommand.parseOrExit()
+    return command.arguments.settings
+}

--- a/Sources/Benchmark/BenchmarkMain.swift
+++ b/Sources/Benchmark/BenchmarkMain.swift
@@ -12,18 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public func main(_ suites: [BenchmarkSuite]) {
-    let command = BenchmarkCommand.parseOrExit()
-    main(suites, settings: command.arguments.settings)
-}
-
-public func main(_ suites: [BenchmarkSuite], settings: [BenchmarkSetting]) {
+public func main(
+    _ suites: [BenchmarkSuite] = [defaultBenchmarkSuite],
+    settings: [BenchmarkSetting] = parseArguments(),
+    customDefaults: [BenchmarkSetting] = defaultSettings
+) {
     var runner = BenchmarkRunner(
         suites: suites,
-        settings: settings)
+        settings: settings,
+        customDefaults: customDefaults)
     try! runner.run()
-}
-
-public func main() {
-    main([defaultBenchmarkSuite])
 }

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -15,16 +15,23 @@
 public struct BenchmarkRunner {
     let suites: [BenchmarkSuite]
     let settings: [BenchmarkSetting]
+    let customDefaults: [BenchmarkSetting]
     let globalSettings: BenchmarkSettings
     var progress: ProgressReporter
     var reporter: BenchmarkReporter
     var results: [BenchmarkResult] = []
 
-    init(suites: [BenchmarkSuite], settings: [BenchmarkSetting]) {
+    init(
+        suites: [BenchmarkSuite],
+        settings: [BenchmarkSetting],
+        customDefaults: [BenchmarkSetting] = []
+    ) {
         self.suites = suites
         self.settings = settings
+        self.customDefaults = customDefaults
         self.globalSettings = BenchmarkSettings([
             defaultSettings,
+            self.customDefaults,
             self.settings,
         ])
         switch self.globalSettings.format {
@@ -61,6 +68,7 @@ public struct BenchmarkRunner {
     mutating func run(benchmark: AnyBenchmark, suite: BenchmarkSuite) throws {
         let settings = BenchmarkSettings([
             defaultSettings,
+            self.customDefaults,
             suite.settings,
             benchmark.settings,
             self.settings,

--- a/Sources/Benchmark/BenchmarkSetting.swift
+++ b/Sources/Benchmark/BenchmarkSetting.swift
@@ -226,7 +226,7 @@ public struct BenchmarkSettings {
     }
 }
 
-let defaultSettings: [BenchmarkSetting] = [
+public let defaultSettings: [BenchmarkSetting] = [
     MaxIterations(1_000_000),
     MinTime(seconds: 1.0),
     TimeUnit(.ns),

--- a/Sources/Benchmark/BenchmarkSuite.swift
+++ b/Sources/Benchmark/BenchmarkSuite.swift
@@ -87,4 +87,4 @@ public class BenchmarkSuite {
     }
 }
 
-var defaultBenchmarkSuite = BenchmarkSuite(name: "")
+public let defaultBenchmarkSuite = BenchmarkSuite(name: "")


### PR DESCRIPTION
Since #45, cli settings have highest priority and can not be used to pass sane global defaults, because they would override benchmark and suite-level settings.  We add a new optional argument to `main` to address this.