### PR TITLE
Add utility methods to work with column registry

### DIFF
--- a/Sources/Benchmark/BenchmarkColumn.swift
+++ b/Sources/Benchmark/BenchmarkColumn.swift
@@ -47,6 +47,12 @@ public struct BenchmarkColumn: Hashable {
         self.formatter = formatter
     }
 
+    /// Create a copy of this column with a different name.
+    public func renamed(_ newName: String) -> BenchmarkColumn {
+        return BenchmarkColumn(
+            name: newName, value: value, alignment: alignment, formatter: formatter)
+    }
+
     /// Registry that represents a mapping from known column
     /// names to their corresponding column values. This
     /// registry can be modified to add custom user-defined
@@ -145,6 +151,11 @@ public struct BenchmarkColumn: Hashable {
 
         return result
     }()
+
+    /// Adds given column to the registry.
+    public static func register(_ column: BenchmarkColumn) {
+        registry[column.name] = column
+    }
 
     public static func == (lhs: Self, rhs: Self) -> Bool {
         return lhs.name == rhs.name

--- a/Tests/BenchmarkTests/BenchmarkColumnTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkColumnTests.swift
@@ -53,7 +53,16 @@ final class BenchmarkColumnTests: XCTestCase {
         XCTAssertTrue(BenchmarkColumn.registry["foobar"] != nil)
     }
 
+    func testRenamed() {
+        let time = BenchmarkColumn.registry["time"]!
+        XCTAssertEqual(time.name, "time") 
+        let mytime = time.renamed("mytime")
+        XCTAssertEqual(mytime.name, "mytime")
+    }
+
     static var allTests = [
-        ("testKnownColumns", testKnownColumns)
+        ("testKnownColumns", testKnownColumns),
+        ("testRegisterColumn", testRegisterColumn),
+        ("testRenamed", testRenamed),
     ]
 }

--- a/Tests/BenchmarkTests/BenchmarkColumnTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkColumnTests.swift
@@ -47,6 +47,12 @@ final class BenchmarkColumnTests: XCTestCase {
         }
     }
 
+    func testRegisterColumn() {
+        BenchmarkColumn.register(
+            BenchmarkColumn.registry["time"]!.renamed("foobar"))
+        XCTAssertTrue(BenchmarkColumn.registry["foobar"] != nil)
+    }
+
     static var allTests = [
         ("testKnownColumns", testKnownColumns)
     ]


### PR DESCRIPTION
This change introduces two helper methods to reduce boilerplate in defining custom columns.