### PR TITLE
Add support for mixed columns

### DIFF
--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -16,7 +16,6 @@ public struct BenchmarkRunner {
     let suites: [BenchmarkSuite]
     let settings: [BenchmarkSetting]
     let customDefaults: [BenchmarkSetting]
-    let globalSettings: BenchmarkSettings
     var progress: ProgressReporter
     var reporter: BenchmarkReporter
     var results: [BenchmarkResult] = []
@@ -29,18 +28,18 @@ public struct BenchmarkRunner {
         self.suites = suites
         self.settings = settings
         self.customDefaults = customDefaults
-        self.globalSettings = BenchmarkSettings([
+        let globalSettings = BenchmarkSettings([
             defaultSettings,
             self.customDefaults,
             self.settings,
         ])
-        switch self.globalSettings.format {
+        switch globalSettings.format {
         case .none:
             self.progress = QuietReporter()
         default:
             self.progress = VerboseProgressReporter(output: StderrOutputStream())
         }
-        switch self.globalSettings.format {
+        switch globalSettings.format {
         case .none:
             self.reporter = QuietReporter()
         case .console:
@@ -56,7 +55,7 @@ public struct BenchmarkRunner {
         for suite in suites {
             try run(suite: suite)
         }
-        reporter.report(results: results, settings: globalSettings)
+        reporter.report(results: results)
     }
 
     mutating func run(suite: BenchmarkSuite) throws {

--- a/Tests/BenchmarkTests/BenchmarkColumnTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkColumnTests.swift
@@ -55,7 +55,7 @@ final class BenchmarkColumnTests: XCTestCase {
 
     func testRenamed() {
         let time = BenchmarkColumn.registry["time"]!
-        XCTAssertEqual(time.name, "time") 
+        XCTAssertEqual(time.name, "time")
         let mytime = time.renamed("mytime")
         XCTAssertEqual(mytime.name, "mytime")
     }


### PR DESCRIPTION
This change makes it possible to define which columns are reported on per-benchmark and per-suite basis:

* In columnar output (Console, CSV), a superset of all requested columns is shown, where only requested benchmark/column cells are non-blank.
* In JSON output, only the columns which were requested are shown in the output. 