### PR TITLE
Make numbers more compact in the console output

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ OPTIONS:
   -h, --help              Show help information.
 
 $ swift run -c release BenchmarkMinimalExample
-running add string no capacity... done! (1795.09 ms)
-running add string reserved capacity... done! (1815.80 ms)
+running add string no capacity... done! (1832.52 ms)
+running add string reserved capacity... done! (1813.96 ms)
 
-name                          time        std                  iterations
--------------------------------------------------------------------------
-add string no capacity        35380.0 ns  ± 5035.122635576142  38603
-add string reserved capacity  37466.0 ns  ± 4940.675061813501  36990
+name                         time     std        iterations
+-----------------------------------------------------------
+add string no capacity       37435 ns ±   6.22 %      37196
+add string reserved capacity 37022 ns ±   1.75 %      37749
 ```
 
 For more examples, see

--- a/Sources/Benchmark/BenchmarkFormatter.swift
+++ b/Sources/Benchmark/BenchmarkFormatter.swift
@@ -22,18 +22,20 @@ public enum BenchmarkFormatter {
         if string.hasSuffix(".0") {
             return String(string.dropLast(2))
         } else {
-            return string
+            return String(format: "%.3f", value)
         }
     }
 
     /// Show number with the corresponding time unit.
     public static let time: Formatter = { (value, settings) in
-        return "\(value) \(settings.timeUnit)"
+        let num = number(value, settings)
+        return "\(num) \(settings.timeUnit)"
     }
 
     /// Show number with the corresponding inverse time unit.
     public static let inverseTime: Formatter = { (value, settings) in
-        return "\(value) /\(settings.inverseTimeUnit)"
+        let num = number(value, settings)
+        return "\(num) /\(settings.inverseTimeUnit)"
     }
 
     /// Show value as percentage.
@@ -43,7 +45,8 @@ public enum BenchmarkFormatter {
 
     /// Show value as plus or minus standard deviation.
     public static let std: Formatter = { (value, settings) in
-        return "± " + String(value)
+        let num = number(value, settings)
+        return "± \(num)"
     }
 
     /// Show value as plus or minus standard deviation in percentage.

--- a/Tests/BenchmarkTests/BenchmarkReporterTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkReporterTests.swift
@@ -67,10 +67,10 @@ final class BenchmarkReporterTests: XCTestCase {
                 counters: [:]),
         ]
         let expected = #"""
-            name         time         std        iterations
-            -----------------------------------------------
-            MySuite.fast    1500.0 ns ±  47.14 %          2
-            MySuite.slow 1500000.0 ns ±  47.14 %          2
+            name         time       std        iterations
+            ---------------------------------------------
+            MySuite.fast    1500 ns ±  47.14 %          2
+            MySuite.slow 1500000 ns ±  47.14 %          2
             """#
         assertConsoleReported(results, expected)
     }
@@ -91,10 +91,10 @@ final class BenchmarkReporterTests: XCTestCase {
                 counters: [:]),
         ]
         let expected = #"""
-            name         time         std        iterations foo
-            ---------------------------------------------------
-            MySuite.fast    1500.0 ns ±  47.14 %          2   7
-            MySuite.slow 1500000.0 ns ±  47.14 %          2   0
+            name         time       std        iterations foo
+            -------------------------------------------------
+            MySuite.fast    1500 ns ±  47.14 %          2   7
+            MySuite.slow 1500000 ns ±  47.14 %          2   0
             """#
         assertConsoleReported(results, expected)
     }
@@ -115,10 +115,10 @@ final class BenchmarkReporterTests: XCTestCase {
                 counters: [:]),
         ]
         let expected = #"""
-            name         time         std        iterations warmup 
-            -------------------------------------------------------
-            MySuite.fast    1500.0 ns ±  47.14 %          2 60.0 ns
-            MySuite.slow 1500000.0 ns ±  47.14 %          2  0.0 ns
+            name         time       std        iterations warmup
+            ----------------------------------------------------
+            MySuite.fast    1500 ns ±  47.14 %          2  60 ns
+            MySuite.slow 1500000 ns ±  47.14 %          2   0 ns
             """#
         assertConsoleReported(results, expected)
     }
@@ -151,12 +151,12 @@ final class BenchmarkReporterTests: XCTestCase {
                 counters: [:]),
         ]
         let expected = #"""
-            name       time           std        iterations
-            -----------------------------------------------
-            MySuite.ns 123456789.0 ns ±   0.00 %          1
-            MySuite.us  123456.789 us ±   0.00 %          1
-            MySuite.ms  123.456789 ms ±   0.00 %          1
-            MySuite.s   0.123456789 s ±   0.00 %          1
+            name       time          std        iterations
+            ----------------------------------------------
+            MySuite.ns  123456789 ns ±   0.00 %          1
+            MySuite.us 123456.789 us ±   0.00 %          1
+            MySuite.ms    123.457 ms ±   0.00 %          1
+            MySuite.s        0.123 s ±   0.00 %          1
             """#
         assertConsoleReported(results, expected)
     }
@@ -177,10 +177,10 @@ final class BenchmarkReporterTests: XCTestCase {
                 counters: [:]),
         ]
         let expected = #"""
-            name         min       max         
-            -----------------------------------
-            MySuite.fast 1000.0 ns             
-            MySuite.slow           2000000.0 ns
+            name         min     max       
+            -------------------------------
+            MySuite.fast 1000 ns           
+            MySuite.slow         2000000 ns
             """#
         assertConsoleReported(results, expected)
     }


### PR DESCRIPTION
This adds a few minor changes to reduce column width of numeric output with console reporter:

* Floating point numbers that end with `.0`, only show the integer part
* Non-integer floating point numbers round off to 3 digits after the dot