### PR TITLE
 Add --quiet flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ more details on what options are available, pass either the `-h` or `--help` com
 Example:
 
 ```terminal
-$ swift run -c release BenchmarkMinimalExample -h
-[3/3] Linking BenchmarkMinimalExample
-USAGE: benchmark-command [--allow-debug-build] [--filter <filter>] [--filter-not <filter-not>] [--iterations <iterations>] [--warmup-iterations <warmup-iterations>] [--min-time <min-time>] [--max-iterations <max-iterations>] [--time-unit <time-unit>] [--inverse-time-unit <inverse-time-unit>] [--columns <columns>] [--format <format>]
+$ swift run -c release BenchmarkMinimalExample --help
+USAGE: benchmark-command [--allow-debug-build] [--filter <filter>] [--filter-not <filter-not>] [--iterations <iterations>] [--warmup-iterations <warmup-iterations>] [--min-time <min-time>] [--max-iterations <max-iterations>] [--time-unit <time-unit>] [--inverse-time-unit <inverse-time-unit>] [--columns <columns>] [--format <format>] [--quiet]
 
 OPTIONS:
   --allow-debug-build     Overrides check to verify optimized build.
@@ -40,13 +39,13 @@ OPTIONS:
                           Number of warm-up iterations to run.
   --min-time <min-time>   Minimal time to run when automatically detecting number iterations.
   --max-iterations <max-iterations>
-                          Maximum number of iterations to run when automatically detecting number
-                          iterations.
+                          Maximum number of iterations to run when automatically detecting number iterations.
   --time-unit <time-unit> Time unit used to report the timing results.
   --inverse-time-unit <inverse-time-unit>
                           Inverse time unit used to report throughput results.
   --columns <columns>     Comma-separated list of column names to show.
   --format <format>       Output format (valid values are: json, csv, console, none).
+  --quiet                 Only print final benchmark results.
   -h, --help              Show help information.
 
 $ swift run -c release BenchmarkMinimalExample

--- a/Sources/Benchmark/BenchmarkArguments.swift
+++ b/Sources/Benchmark/BenchmarkArguments.swift
@@ -51,6 +51,9 @@ public struct BenchmarkArguments: ParsableArguments {
     @Option(help: "Output format (valid values are: json, csv, console, none).")
     var format: Format.Value?
 
+    @Flag(help: "Only print final benchmark results.")
+    var quiet: Bool
+
     public init() {}
 
     /// Conversion from command-line arguments to benchmark settings.
@@ -87,6 +90,9 @@ public struct BenchmarkArguments: ParsableArguments {
         }
         if let value = format {
             result.append(Format(value))
+        }
+        if quiet {
+            result.append(Quiet(true))
         }
 
         return result

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -33,10 +33,9 @@ public struct BenchmarkRunner {
             self.customDefaults,
             self.settings,
         ])
-        switch globalSettings.format {
-        case .none:
+        if globalSettings.quiet {
             self.progress = QuietReporter()
-        default:
+        } else {
             self.progress = VerboseProgressReporter(output: StderrOutputStream())
         }
         switch globalSettings.format {

--- a/Sources/Benchmark/BenchmarkSetting.swift
+++ b/Sources/Benchmark/BenchmarkSetting.swift
@@ -115,6 +115,14 @@ public struct Format: BenchmarkSetting {
     }
 }
 
+/// The output format used to show the results.
+public struct Quiet: BenchmarkSetting {
+    public var value: Bool
+    public init(_ value: Bool) {
+        self.value = value
+    }
+}
+
 /// An aggregate of all benchmark settings, that deduplicates
 /// the settings based on their type. A setting which is defined
 /// multiple times, only retains its last set value.
@@ -237,6 +245,15 @@ public struct BenchmarkSettings {
             fatalError("format must have a default.")
         }
     }
+
+    /// Convenience accessor for the TimeUnit setting. 
+    public var quiet: Bool {
+        if let value = self[Quiet.self]?.value {
+            return value
+        } else {
+            fatalError("quiet must have a default.")
+        }
+    }
 }
 
 public let defaultSettings: [BenchmarkSetting] = [
@@ -245,4 +262,5 @@ public let defaultSettings: [BenchmarkSetting] = [
     TimeUnit(.ns),
     InverseTimeUnit(.s),
     Format(.console),
+    Quiet(false),
 ]

--- a/Sources/Benchmark/BenchmarkSetting.swift
+++ b/Sources/Benchmark/BenchmarkSetting.swift
@@ -115,7 +115,7 @@ public struct Format: BenchmarkSetting {
     }
 }
 
-/// The output format used to show the results.
+/// If quiet is set to true, don't show intermediate progress updates.
 public struct Quiet: BenchmarkSetting {
     public var value: Bool
     public init(_ value: Bool) {
@@ -246,7 +246,7 @@ public struct BenchmarkSettings {
         }
     }
 
-    /// Convenience accessor for the TimeUnit setting. 
+    /// Convenience accessor for the Quiet setting. 
     public var quiet: Bool {
         if let value = self[Quiet.self]?.value {
             return value

--- a/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkRunnerTests.swift
@@ -124,7 +124,7 @@ final class BenchmarkRunnerTests: XCTestCase {
 
 extension BenchmarkRunnerTests {
     func run(suites: [BenchmarkSuite], settings: [BenchmarkSetting]) throws -> [BenchmarkResult] {
-        var allSettings: [BenchmarkSetting] = [Format(.none)]
+        var allSettings: [BenchmarkSetting] = [Format(.none), Quiet(true)]
         allSettings.append(contentsOf: settings)
         var runner = BenchmarkRunner(
             suites: suites,

--- a/Tests/BenchmarkTests/BenchmarkSettingTests.swift
+++ b/Tests/BenchmarkTests/BenchmarkSettingTests.swift
@@ -24,7 +24,7 @@ final class BenchmarkSettingTests: XCTestCase {
         cli: [BenchmarkSetting],
         customDefaults: [BenchmarkSetting] = []
     ) throws {
-        var settings: [BenchmarkSetting] = [Format(.none)]
+        var settings: [BenchmarkSetting] = [Format(.none), Quiet(true)]
         settings.append(contentsOf: cli)
         var runner = BenchmarkRunner(
             suites: [suite], settings: settings, customDefaults: customDefaults)

--- a/Tests/BenchmarkTests/CustomBenchmarkTests.swift
+++ b/Tests/BenchmarkTests/CustomBenchmarkTests.swift
@@ -23,7 +23,7 @@ final class CustomBenchmarkTests: XCTestCase {
         let suite = BenchmarkSuite(name: "suite")
         suite.benchmarks = [benchmark]
 
-        var runner = BenchmarkRunner(suites: [suite], settings: [Format(.none)])
+        var runner = BenchmarkRunner(suites: [suite], settings: [Format(.none), Quiet(true)])
 
         try runner.run()
 


### PR DESCRIPTION
This change introduces a new flag: `--quiet`. When this flag is passed, swift-benchmark doesn't attempt to show fine-grain progress while running the benchmark, and only shows the final result when the complete benchmark run is complete.