### PR TITLE
Make `BenchmarkRunner` publicly accessible

### DIFF
--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -18,6 +18,8 @@ public struct BenchmarkRunner {
     let customDefaults: [BenchmarkSetting]
     var progress: ProgressReporter
     var reporter: BenchmarkReporter
+
+    /// Settings used and measurements taken.
     public var results: [BenchmarkResult] = []
 
     public init(
@@ -50,6 +52,7 @@ public struct BenchmarkRunner {
         }
     }
 
+    /// Executes each suite in `self.suites` and reports results.
     public mutating func run() throws {
         for suite in suites {
             try run(suite: suite)

--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -18,9 +18,9 @@ public struct BenchmarkRunner {
     let customDefaults: [BenchmarkSetting]
     var progress: ProgressReporter
     var reporter: BenchmarkReporter
-    var results: [BenchmarkResult] = []
+    public var results: [BenchmarkResult] = []
 
-    init(
+    public init(
         suites: [BenchmarkSuite],
         settings: [BenchmarkSetting],
         customDefaults: [BenchmarkSetting] = []
@@ -50,7 +50,7 @@ public struct BenchmarkRunner {
         }
     }
 
-    mutating func run() throws {
+    public mutating func run() throws {
         for suite in suites {
             try run(suite: suite)
         }


### PR DESCRIPTION
Makes `BenchmarkRunner` publicly accessible, for short-circuiting `BenchmarkMain` and accessing result measurements directly. This is useful for sending individual results to other systems, rather than just printing a summary.