### PR TITLE
Compatibility with latest ArgumentParser deprecations

### DIFF
--- a/Sources/Benchmark/BenchmarkArguments.swift
+++ b/Sources/Benchmark/BenchmarkArguments.swift
@@ -18,7 +18,7 @@ import ArgumentParser
 /// all of the default benchmark settings. 
 public struct BenchmarkArguments: ParsableArguments {
     @Flag(help: "Overrides check to verify optimized build.")
-    var allowDebugBuild: Bool
+    var allowDebugBuild: Bool = false
 
     @Option(help: "Run only benchmarks whose names match the regular expression.")
     var filter: String?
@@ -52,7 +52,7 @@ public struct BenchmarkArguments: ParsableArguments {
     var format: Format.Value?
 
     @Flag(help: "Only print final benchmark results.")
-    var quiet: Bool
+    var quiet: Bool = false
 
     public init() {}
 


### PR DESCRIPTION
Suppress these warnings:

```
…/.build/checkouts/swift-benchmark/Sources/Benchmark/BenchmarkArguments.swift:20:6: warning: 'init(name:help:)' is deprecated: Provide an explicit default value of `false` for this flag (`@Flag var foo: Bool = false`)
    @Flag(help: "Overrides check to verify optimized build.")
     ^
…/.build/checkouts/swift-benchmark/Sources/Benchmark/BenchmarkArguments.swift:54:6: warning: 'init(name:help:)' is deprecated: Provide an explicit default value of `false` for this flag (`@Flag var foo: Bool = false`)
    @Flag(help: "Only print final benchmark results.")
     ^
```