### PR TITLE
Add script to compare benchmark results

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "eb51f949cdd0c9d88abba9ce79d37eb7ea1231d0",
-          "version": "0.2.0"
+          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
+          "version": "0.3.1"
         }
       }
     ]

--- a/Scripts/compare.py
+++ b/Scripts/compare.py
@@ -6,12 +6,8 @@ import argparse
 import re
 
 
-def fail(msg):
-    raise Exception(msg)
-
-
 def require(cond, msg):
-    if not cond: fail(msg)
+    if not cond: raise Exception(msg)
 
 
 def validate(file_name, parsed):
@@ -40,7 +36,7 @@ def parse_and_validate(args):
             try:
                 parsed = json.load(f)
             except Exception as err:
-                fail("failed to parse json: {}".format(err))
+                raise Exception("failed to parse json: {}".format(err))
             validate(file_name, parsed)
             runs.append((file_name, parsed))
 

--- a/Scripts/compare.py
+++ b/Scripts/compare.py
@@ -7,10 +7,14 @@ import re
 
 
 def require(cond, msg):
+    """Fails with a message if condition is not true."""
+
     if not cond: raise Exception(msg)
 
 
 def validate(file_name, parsed):
+    """Validates that given json object is a valid benchmarks result."""
+
     require("benchmarks" in parsed, 
             "{}: missing key 'benchmarks'.".format(file_name))
     require(len(parsed["benchmarks"]) > 0, 
@@ -28,6 +32,8 @@ def validate(file_name, parsed):
 
 
 def parse_and_validate(args):
+    """Parse command-line args, parse given json files and validate their contents."""
+
     runs = []
 
     for file_name in args.file_names:
@@ -44,6 +50,8 @@ def parse_and_validate(args):
 
 
 def benchmark_predicate(args):
+    """Returns a predicate used to filter benchmark columns based on cli args."""
+
     include = lambda x: True
 
     if args.filter:
@@ -60,6 +68,8 @@ def benchmark_predicate(args):
 
 
 def collect_values(args, runs):
+    """Collect benchmark values for the comparison, excluding filtered out columns."""
+
     baseline_name, baseline = runs[0]
 
     include_benchmark = benchmark_predicate(args)
@@ -92,6 +102,8 @@ def collect_values(args, runs):
 
 
 def geomean(values):
+    """Compute geometric mean for the given sequence of values."""
+
     product = 1.0
     for value in values:
         product *= value 
@@ -99,6 +111,8 @@ def geomean(values):
 
 
 def to_table(confs, args, values):
+    """Compute a table of relative results across all input files."""
+
     baseline_file_name = args.baseline
     rows = [] 
 
@@ -158,6 +172,8 @@ def to_table(confs, args, values):
 
 
 def pad(base, fill, count, right = False):
+    """Pad base string with given fill until count, on either left or right.""" 
+
     while len(base) < count:
         if right:
             base += fill
@@ -167,13 +183,15 @@ def pad(base, fill, count, right = False):
 
 
 def print_table(table):
+    """Pretty print results table as aligned human-readable text."""
+
     # Collect width of each max column.
     widths = defaultdict(lambda: 0)
     for row in table:
         for ncol, col in enumerate(row):
             widths[ncol] = max(widths[ncol], len(str(col)))
 
-    # Print results as an aligned human-readable table.
+    # Print results as an aligned text to stdout.
     totals = False
     for nrow, row in enumerate(table):
         if row[0] == '' and not totals:
@@ -189,6 +207,8 @@ def print_table(table):
 
 
 def parse_args():
+    """Parse command-line flags into a configuration object, and return it."""
+
     parser = argparse.ArgumentParser(description="Compare multiple swift-benchmark json files.")
     parser.add_argument("baseline", help="Baseline json file to compare against.")
     parser.add_argument("candidate", nargs="+", 
@@ -196,15 +216,19 @@ def parse_args():
     parser.add_argument("--filter", help="Only show benchmarks that match the regular expression.")
     parser.add_argument("--filter-not", help="Exclude benchmarks whose names match the regular expression.")
     parser.add_argument("--columns", help="A comma-separated list of columns to show.")
+
     args = parser.parse_args()
     args.file_names = [args.baseline]
     args.file_names.extend(args.candidate)
     if args.columns is not None:
         args.columns = set(args.columns.split(","))
+
     return args
 
 
 def main():
+    """Command-line entry-point."""
+
     args = parse_args()
     runs = parse_and_validate(args)
     confs, values = collect_values(args, runs)

--- a/Scripts/compare.py
+++ b/Scripts/compare.py
@@ -1,0 +1,145 @@
+import sys
+import json
+from pprint import pprint
+from collections import defaultdict
+
+
+def fail(msg):
+    raise Exception(msg)
+
+
+def require(cond, msg):
+    if not cond:
+        fail(msg)
+
+
+def validate(file_name, parsed):
+    require("benchmarks" in parsed, 
+            "{}: missing key 'benchmarks'.".format(file_name))
+    require(len(parsed["benchmarks"]) > 0, 
+            "{}: must have at least one benchmark.".format(file_name))
+
+    for i, benchmark in enumerate(parsed["benchmarks"]):
+        require("name" in benchmark,
+                "{}: benchmark #{}: missing key 'name'.".format(file_name, i))
+
+        for k, v in benchmark.items():
+            if k != "name":
+                is_num = isinstance(v, int) or isinstance(v, float)
+                template = "{}: benchmark #{}: values must be numbers."
+                require(is_num, template.format(file_name, i))
+
+
+def parse_and_validate(file_names):
+    if len(file_names) < 2:
+        fail("must provide two or more files to compare.") 
+
+    runs = []
+
+    for file_name in file_names:
+        with open(file_name) as f:
+            parsed = None
+            try:
+                parsed = json.load(f)
+            except Exception as err:
+                fail("failed to parse json: {}".format(err))
+            validate(file_name, parsed)
+            runs.append((file_name, parsed))
+
+    return runs
+
+
+def extract_values(runs):
+    baseline_name, baseline = runs[0]
+
+    confs = []
+    values = {}
+
+    for benchmark in baseline["benchmarks"]:
+        benchmark_name = benchmark["name"]
+        for column in benchmark.keys():
+            if column == "name":
+                continue
+            conf = (benchmark_name, column)
+            confs.append(conf)
+            values[conf] = {}
+
+    for conf in confs:
+        bench_name, column = conf
+        for (file_name, run) in runs:
+            for bench in run["benchmarks"]:
+                if bench["name"] == bench_name:
+                    values[conf][file_name] = bench[column]
+
+    return (confs, values)
+
+
+def to_table(confs, file_names, values):
+    baseline_file_name = file_names[0]
+    rows = [] 
+
+    # Header row.
+    header = []
+    header.append("benchmark")
+    header.append("column")
+    for (n, file_name) in enumerate(file_names):
+        name = file_name.replace(".json", "")
+        header.append(name)
+        if n != 0:
+            header.append("%")
+    rows.append(header)
+
+    # Body rows.
+    for conf in confs:
+        bench_name, column = conf
+        row = []
+        row.append(bench_name)
+        row.append(column)
+        for n, file_name in enumerate(file_names):
+            base_value = values[conf][baseline_file_name]
+            value = values[conf][file_name]
+            row.append("{:.2f}".format(value))
+            if n != 0:
+                relative = value/base_value
+                relative_percentage = (1 - relative ) * 100
+                row.append("{:.2f}".format(relative_percentage))
+        rows.append(row)
+
+    return rows
+
+
+def pad(base, fill, count, right = False):
+    while len(base) < count:
+        if right:
+            base += fill
+        else:
+            base = fill + base
+    return base
+
+
+def print_table(table):
+    widths = defaultdict(lambda: 0)
+    for row in table:
+        for ncol, col in enumerate(row):
+            widths[ncol] = max(widths[ncol], len(str(col)))
+
+    for nrow, row in enumerate(table):
+        line = []
+        for ncol, col in enumerate(row):
+            right = ncol == 0 or ncol == 1
+            line.append(pad(str(col), " ", widths[ncol], right = right))
+        print(" ".join(line))
+        if nrow == 0:
+            print("-" * (sum(widths.values()) + len(widths) - 1))
+
+
+def main():
+    file_names = sys.argv[1:]
+    runs = parse_and_validate(file_names)
+    confs, values = extract_values(runs)
+    table = to_table(confs, file_names, values)
+    print_table(table)
+
+
+if __name__ == "__main__":
+    main()

--- a/Scripts/compare.py
+++ b/Scripts/compare.py
@@ -1,3 +1,18 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import sys
 import json
 from pprint import pprint

--- a/Scripts/compare.py
+++ b/Scripts/compare.py
@@ -47,7 +47,7 @@ def parse_and_validate(args):
     return runs
 
 
-def include_predicate(args):
+def benchmark_predicate(args):
     include = lambda x: True
 
     if args.filter:
@@ -66,17 +66,20 @@ def include_predicate(args):
 def collect_values(args, runs):
     baseline_name, baseline = runs[0]
 
-    include = include_predicate(args)
+    include_benchmark = benchmark_predicate(args)
+    include_column = lambda x: args.columns is None or x in args.columns
 
     confs = []
     values = {}
 
     for benchmark in baseline["benchmarks"]:
         benchmark_name = benchmark["name"]
-        if not include(benchmark_name):
+        if not include_benchmark(benchmark_name):
             continue
         for column in benchmark.keys():
             if column == "name":
+                continue
+            if not include_column(column):
                 continue
             conf = (benchmark_name, column)
             confs.append(conf)
@@ -196,9 +199,12 @@ def parse_args():
                         help="Candidate json files to compare against baseline.") 
     parser.add_argument("--filter", help="Only show benchmarks that match the regular expression.")
     parser.add_argument("--filter-not", help="Exclude benchmarks whose names match the regular expression.")
+    parser.add_argument("--columns", help="A comma-separated list of columns to show.")
     args = parser.parse_args()
     args.file_names = [args.baseline]
     args.file_names.extend(args.candidate)
+    if args.columns is not None:
+        args.columns = set(args.columns.split(","))
     return args
 
 


### PR DESCRIPTION
This changes adds a python script to compare json results generated by swift-benchmark. Script accepts two or more json files as input. First file is used as a baseline for comparison purposes. Metrics from each subsequent file are reported relative to baseline as a ratio and a percentage change. After all relative comparison, script also includes a geomean-based total results over all benchmarks. 

Additionally, you can also pass the following flags:

1. `--filter regex`. A regular expression to filter benchmarks to be shown in the output.
2. `--filter-not regex`. A regular expression to filter benchmarks to be excluded from the output.
3. `--columns col1,col2`. A comma-separated list of columns that we want to compare. By default all columns are show.

Example output: 

```text
$ python Scripts/compare.py a.json b.json 
benchmark                    column             a         b relative     %
--------------------------------------------------------------------------
add string no capacity       iterations   7202.00   7149.00     0.99 -0.74
add string reserved capacity iterations   7269.00   7164.00     0.99 -1.44
add string no capacity       std             1.48      1.41     0.95 -4.76
add string reserved capacity std             1.01      1.41     1.40 39.70
add string no capacity       time       193653.00 196677.00     1.02  1.56
add string reserved capacity time       192059.00 194472.00     1.01  1.26
--------------------------------------------------------------------------
                             iterations                         0.99 -1.09
                             std                                1.15 15.35
                             time                               1.01  1.41
```