### PR TITLE
Use Swift 5.4 for Windows job on GitHub Actions

### DIFF
--- a/.github/workflows/tests_mac.yaml
+++ b/.github/workflows/tests_mac.yaml
@@ -1,5 +1,9 @@
 name: tests-macos
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+
 jobs:
   macOS:
     name: macOS

--- a/.github/workflows/tests_ubuntu.yaml
+++ b/.github/workflows/tests_ubuntu.yaml
@@ -1,5 +1,9 @@
 name: tests-ubuntu
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+
 jobs:
   ubuntu:
     name: Ubuntu 18.04

--- a/.github/workflows/tests_windows.yaml
+++ b/.github/workflows/tests_windows.yaml
@@ -1,5 +1,9 @@
 name: tests-windows
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+
 jobs:
   windows:
     name: windows

--- a/.github/workflows/tests_windows.yaml
+++ b/.github/workflows/tests_windows.yaml
@@ -5,11 +5,11 @@ jobs:
     name: windows
     runs-on: windows-latest
     steps:
-    - uses: seanmiddleditch/gha-setup-vsdevenv@master
+    - uses: seanmiddleditch/gha-setup-vsdevenv@v3
 
-    - name: Install swift-DEVELOPMENT-SNAPSHOT-2020-09-22-a
+    - name: Install Swift 5.4
       run: |
-        Install-Binary -Url "https://swift.org/builds/development/windows10/swift-DEVELOPMENT-SNAPSHOT-2020-09-22-a/swift-DEVELOPMENT-SNAPSHOT-2020-09-22-a-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
+        Install-Binary -Url "https://swift.org/builds/swift-5.4.2-release/windows10/swift-5.4.2-RELEASE/swift-5.4.2-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
 
     - name: Set Environment Variables
       run: |
@@ -32,7 +32,7 @@ jobs:
       run: swift --version
 
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Build
       run: swift build -v

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "eb51f949cdd0c9d88abba9ce79d37eb7ea1231d0",
-          "version": "0.2.0"
+          "revision": "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
+          "version": "0.5.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
             targets: ["Benchmark"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.0.1"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.5.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
I've updated the Windows job on GitHub Actions to use a release build of Swift 5.4, and also updated the dependency in `Package.swift` and `Package.resolved`.

Additionally, all GitHub Actions triggers were updated to prevent jobs from running twice on pull requests created from branches in the same repositories.