### PR TITLE
CI: Simplify the Windows CI rules

### DIFF
--- a/.github/workflows/tests_windows.yaml
+++ b/.github/workflows/tests_windows.yaml
@@ -9,28 +9,10 @@ jobs:
     name: windows
     runs-on: windows-latest
     steps:
-    - uses: seanmiddleditch/gha-setup-vsdevenv@v3
-
-    - name: Install Swift 5.4
-      run: |
-        Install-Binary -Url "https://swift.org/builds/swift-5.4.2-release/windows10/swift-5.4.2-RELEASE/swift-5.4.2-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
-
-    - name: Set Environment Variables
-      run: |
-        echo "SDKROOT=C:\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        echo "DEVELOPER_DIR=C:\Library\Developer" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-    - name: Adjust Paths
-      run: |
-        echo "C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo "C:\Library\Swift-development\bin;C:\Library\icu-67\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-    - name: Install Supporting Files
-      run: |
-        Copy-Item "$env:SDKROOT\usr\share\ucrt.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\ucrt\module.modulemap"
-        Copy-Item "$env:SDKROOT\usr\share\visualc.modulemap" -destination "$env:VCToolsInstallDir\include\module.modulemap"
-        Copy-Item "$env:SDKROOT\usr\share\visualc.apinotes" -destination "$env:VCToolsInstallDir\include\visualc.apinotes"
-        Copy-Item "$env:SDKROOT\usr\share\winsdk.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\um\module.modulemap"
+    - uses: compnerd/gha-setup-swift@main
+      with:
+        branch: swift-5.4.3-release
+        tag: 5.4.3-RELEASE
 
     - name: Swift version
       run: swift --version


### PR DESCRIPTION
Rely on compnerd/gha-setup-swift to install and configure Swift rather than manually doing so.  This reduces the complexity of the CI configuration.