### PR TITLE
Report os_signposts on Darwin, split warmup reporting

### DIFF
--- a/Sources/Benchmark/BenchmarkRunner.swift
+++ b/Sources/Benchmark/BenchmarkRunner.swift
@@ -85,14 +85,20 @@ public struct BenchmarkRunner {
             return
         }
 
-        progress.report(running: benchmark.name, suite: suite.name)
+        progress.reportWillBeginBenchmark(benchmark, suite: suite)
         let totalStart = now()
 
         var warmupState: BenchmarkState? = nil
         if settings.warmupIterations > 0 {
-            warmupState = doNIterations(
+            progress.reportWarmingUp()
+            let state = doNIterations(
                 settings.warmupIterations, benchmark: benchmark, suite: suite, settings: settings)
+            let warmupElapsed = state.endTime - state.startTime
+            progress.reportFinishedWarmup(nanosTaken: warmupElapsed)
+            warmupState = state
         }
+
+        progress.reportRunning()
 
         var state: BenchmarkState
         if let n = settings.iterations {
@@ -105,8 +111,8 @@ public struct BenchmarkRunner {
         let totalEnd = now()
         let totalElapsed = totalEnd - totalStart
 
-        progress.report(
-            finishedRunning: benchmark.name, suite: suite.name, nanosTaken: totalElapsed)
+        progress.reportFinishedRunning(nanosTaken: state.endTime - state.startTime)
+        progress.reportFinishedBenchmark(nanosTaken: totalElapsed)
 
         let result = BenchmarkResult(
             benchmarkName: benchmark.name,

--- a/Tests/BenchmarkTests/CMakeLists.txt
+++ b/Tests/BenchmarkTests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(BenchmarkTests
   BenchmarkSuiteTests.swift
   CustomBenchmarkTests.swift
   MockTextOutputStream.swift
+  ProgressReporterTests.swift
   StatsTests.swift
   XCTTestManifests.swift)
 

--- a/Tests/BenchmarkTests/ProgressReporterTests.swift
+++ b/Tests/BenchmarkTests/ProgressReporterTests.swift
@@ -1,0 +1,139 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import Benchmark
+
+final class ProgressReporterTests: XCTestCase {
+
+    fileprivate var dummySuite: BenchmarkSuite {
+        BenchmarkSuite(name: "SomeSuite") { suite in
+            suite.benchmark("SomeBenchmark") { /* No-op */  }
+            suite.benchmark("AnotherBenchmark") { /* No-op */  }
+        }
+    }
+
+    open class DummyProgressReporterBase: ProgressReporter {
+        var didReportWillBegin = false
+        var didReportWarmingUp = false
+        var didReportFinishedWarmup = false
+        var didReportRunning = false
+        var didReportFinishedRunning = false
+        var benchmarksFinished = 0
+
+        init() {}
+
+        private func resetCallbackFlags() {
+            didReportWillBegin = false
+            didReportWarmingUp = false
+            didReportFinishedWarmup = false
+            didReportRunning = false
+            didReportFinishedRunning = false
+        }
+
+        open func reportWillBeginBenchmark(_ benchmark: AnyBenchmark, suite: BenchmarkSuite) {
+            resetCallbackFlags()
+            didReportWillBegin = true
+        }
+
+        open func reportFinishedBenchmark(nanosTaken: UInt64) {
+            resetCallbackFlags()
+            benchmarksFinished += 1
+        }
+
+        open func reportWarmingUp() {
+            didReportWarmingUp = true
+        }
+
+        open func reportFinishedWarmup(nanosTaken: UInt64) {
+            didReportFinishedWarmup = true
+        }
+
+        open func reportRunning() {
+            didReportRunning = true
+        }
+
+        open func reportFinishedRunning(nanosTaken: UInt64) {
+            didReportFinishedRunning = true
+        }
+    }
+
+    func testProgressReportNoWarmup() throws {
+
+        class Reporter: DummyProgressReporterBase {
+            var remainingBenchmarks = ["SomeBenchmark", "AnotherBenchmark"]
+
+            override func reportWillBeginBenchmark(
+                _ benchmark: AnyBenchmark, suite: BenchmarkSuite
+            ) {
+                super.reportWillBeginBenchmark(benchmark, suite: suite)
+                XCTAssertEqual(benchmark.name, remainingBenchmarks.removeFirst())
+                XCTAssertEqual(suite.name, "SomeSuite")
+            }
+            override func reportFinishedBenchmark(nanosTaken: UInt64) {
+                XCTAssertTrue(didReportWillBegin)
+                XCTAssertFalse(didReportWarmingUp)
+                XCTAssertFalse(didReportFinishedWarmup)
+                XCTAssertTrue(didReportRunning)
+                XCTAssertTrue(didReportFinishedRunning)
+                super.reportFinishedBenchmark(nanosTaken: nanosTaken)
+            }
+        }
+
+        let reporter = Reporter()
+        var runner = BenchmarkRunner(suites: [dummySuite], settings: [Iterations(5)])
+        runner.progress = reporter
+        try runner.run()
+        XCTAssertEqual(reporter.remainingBenchmarks, [])
+        XCTAssertEqual(reporter.benchmarksFinished, 2)
+    }
+
+    func testProgressReportWithWarmup() throws {
+
+        class Reporter: DummyProgressReporterBase {
+            var remainingBenchmarks = ["SomeBenchmark", "AnotherBenchmark"]
+
+            override func reportWillBeginBenchmark(
+                _ benchmark: AnyBenchmark, suite: BenchmarkSuite
+            ) {
+                super.reportWillBeginBenchmark(benchmark, suite: suite)
+                XCTAssertEqual(benchmark.name, remainingBenchmarks.removeFirst())
+                XCTAssertEqual(suite.name, "SomeSuite")
+            }
+            override func reportFinishedBenchmark(nanosTaken: UInt64) {
+                XCTAssertTrue(didReportWillBegin)
+                XCTAssertTrue(didReportWarmingUp)
+                XCTAssertTrue(didReportFinishedWarmup)
+                XCTAssertTrue(didReportRunning)
+                XCTAssertTrue(didReportFinishedRunning)
+                super.reportFinishedBenchmark(nanosTaken: nanosTaken)
+            }
+        }
+
+        let reporter = Reporter()
+        var runner = BenchmarkRunner(
+            suites: [dummySuite], settings: [WarmupIterations(42), Iterations(5)]
+        )
+        runner.progress = reporter
+        try runner.run()
+        XCTAssertEqual(reporter.remainingBenchmarks, [])
+        XCTAssertEqual(reporter.benchmarksFinished, 2)
+    }
+
+    static var allTests = [
+        ("testProgressReportNoWarmup", testProgressReportNoWarmup),
+        ("testProgressReportWithWarmup", testProgressReportWithWarmup),
+    ]
+}

--- a/Tests/BenchmarkTests/XCTTestManifests.swift
+++ b/Tests/BenchmarkTests/XCTTestManifests.swift
@@ -24,6 +24,7 @@ import XCTest
             testCase(BenchmarkSettingTests.allTests),
             testCase(BenchmarkSuiteTests.allTests),
             testCase(CustomBenchmarkTests.allTests),
+            testCase(ProgressReporterTests.allTests),
             testCase(StatsTests.allTests),
         ]
     }


### PR DESCRIPTION
This PR does 2 things:

1. Splits warmup reporting, if warmup iterations are specified:

```
karl@Karls-MBP Benchmarks % ./.build/release/WebURLBenchmark --filter "Foundation" --warmup-iterations 20000
Warming up... Running FoundationCompat.ToWeb: AverageURLs... Done! (3944.60 ms)
Warming up... Running FoundationCompat.ToWeb: IPv4... Done! (4075.08 ms)
Warming up... Running FoundationCompat.ToWeb: IPv6... Done! (3421.14 ms)

karl@Karls-MBP Benchmarks % ./.build/release/WebURLBenchmark --filter "Foundation"                          
Running FoundationCompat.ToWeb: AverageURLs... Done! (1496.40 ms)
Running FoundationCompat.ToWeb: IPv4... Done! (2351.41 ms)
Running FoundationCompat.ToWeb: IPv6... Done! (1448.58 ms)
```

2. Adds `os_signpost` reporting on platforms where `OSLog` is available, so Instruments can show which benchmark is running at which time, and similarly split that in to warmup/benchmark sections:

<img width="1096" alt="image" src="https://user-images.githubusercontent.com/5254025/153101219-71867ace-1b52-4939-bbf6-48f652bef862.png">

<img width="953" alt="image" src="https://user-images.githubusercontent.com/5254025/153101380-5d00aa8c-1796-44be-9baa-06f879c91715.png">
